### PR TITLE
fix(project): Scope status validation bypass to new documents

### DIFF
--- a/project_enhancements/project_enhancements/doctype/project/project.py
+++ b/project_enhancements/project_enhancements/doctype/project/project.py
@@ -42,5 +42,5 @@ def validate_project_status(doc, method):
         doc (frappe.model.document.Document): The project document being saved.
         method (str): The method that triggered the hook (e.g., 'on_update').
     """
-    if doc.status == "Open":
+    if doc.is_new() and doc.status == "Open":
         doc.status = "Active"


### PR DESCRIPTION
Refines the `before_save` hook to only change the Project status from "Open" to "Active" when the document is new (`doc.is_new()`).

This prevents the hook from interfering with status changes on existing projects, resolving an issue where users were unable to update the status of a project after it was created.