### PR TITLE
feat: Add task_tree_view to Master Project

### DIFF
--- a/project_enhancements/fixtures/custom_field.json
+++ b/project_enhancements/fixtures/custom_field.json
@@ -91,5 +91,13 @@
   "label": "Tasks Tree View",
   "insert_after": "custom_tasks_section",
   "name": "Project-custom_tasks_html"
+ },
+ {
+  "doctype": "Custom Field",
+  "dt": "Master Project",
+  "fieldname": "task_tree_view",
+  "fieldtype": "HTML",
+  "label": "Project Tree View",
+  "name": "Master Project-task_tree_view"
  }
 ]


### PR DESCRIPTION
Adds the missing custom HTML field `task_tree_view` to `Master Project` which lets `project_tree_manager.js` properly attach itself to the field and render the list of Projects for the master project.

---
*PR created automatically by Jules for task [4144583994254237719](https://jules.google.com/task/4144583994254237719) started by @parker-bailey*