### PR TITLE
fix: Master Project Tree View not rendering in custom tasks html field

### DIFF
--- a/project_enhancements/public/js/master_project_form_script.js
+++ b/project_enhancements/public/js/master_project_form_script.js
@@ -3,12 +3,14 @@
 frappe.ui.form.on('Master Project', {
     // The 'refresh' trigger ensures our script runs every time the form is loaded or refreshed.
     refresh: function(frm) {
-        // Initialize Project Tree in task_tree_view field
-        if (frm.fields_dict['task_tree_view'] && !frm.project_tree_instance) {
+        // Check for either the task_tree_view or custom_tasks_html field to initialize the tree
+        const targetField = frm.fields_dict['task_tree_view'] || frm.fields_dict['custom_tasks_html'];
+
+        if (targetField && !frm.project_tree_instance) {
             // Check if the global namespace and class exist
             if (window.project_enhancements && project_enhancements.ProjectTreeManager) {
                 frm.project_tree_instance = new project_enhancements.ProjectTreeManager({
-                    wrapper: frm.fields_dict['task_tree_view'].wrapper,
+                    wrapper: targetField.wrapper,
                     masterProjectName: frm.doc.name
                 });
             } else {


### PR DESCRIPTION
The Project Tree Manager on the Master Project doctype was failing to display because the script strictly looked for `frm.fields_dict['task_tree_view']` which is defined in the standard custom field fixtures. However, based on the provided screenshot showing a custom layout and a "Tasks Tree" label, it appeared that a `custom_tasks_html` field had been mapped/moved into the Master Project form view instead. This change updates `master_project_form_script.js` to look for either `task_tree_view` or `custom_tasks_html`, ensuring the tree structure logic targets the correct wrapper and renders as expected regardless of which custom HTML field name was placed there.

---
*PR created automatically by Jules for task [12373629135225788694](https://jules.google.com/task/12373629135225788694) started by @parker-bailey*