### PR TITLE
fix: assign project dashboard to standard projects module

### DIFF
--- a/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.json
+++ b/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.json
@@ -6,7 +6,7 @@
  "idx": 0,
  "modified": "2024-08-21 12:00:00.000000",
  "modified_by": "Administrator",
- "module": "Project Enhancements",
+ "module": "Projects",
  "name": "project-dashboard",
  "owner": "Administrator",
  "page_name": "Project Dashboard",


### PR DESCRIPTION
This commit updates `project_dashboard.json` to change the module assignment from "Project Enhancements" to "Projects". This fulfills the requirement to have the Project Dashboard display within the default "Projects" workspace sidebar context.

---
*PR created automatically by Jules for task [17094700135702367223](https://jules.google.com/task/17094700135702367223) started by @nbbshaw*