### PR TITLE
feat: add custom sorting and grouping views to priority overview

### DIFF
--- a/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.js
+++ b/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.js
@@ -105,6 +105,10 @@ frappe.pages['project-dashboard'].on_page_load = function (wrapper) {
                         <button type="button" class="btn btn-sm btn-default" id="add-filter-btn">
                             <i class="fa fa-filter"></i> Add Filter
                         </button>
+                        <div id="priority-overview-filters" style="display: none;" class="ml-2 btn-group btn-group-sm">
+                            <button type="button" class="btn btn-default active" id="filter-company-priority">Company Priority</button>
+                            <button type="button" class="btn btn-default" id="filter-value-stream">Project Priority by Value Stream</button>
+                        </div>
                     </div>
                     <div class="col-md-4 text-right">
                         <div id="global-pending-changes" style="display: none;">
@@ -143,6 +147,15 @@ frappe.pages['project-dashboard'].on_page_load = function (wrapper) {
                     currentComponent.unmount();
                 }
                 currentComponent = null;
+            }
+
+            // Show or hide Priority Overview specific controls
+            if (moduleRoute === 'priority-overview') {
+                $('#priority-overview-filters').show();
+                // Reset active state to default when returning to the tab
+                $('#filter-company-priority').addClass('active').siblings().removeClass('active');
+            } else {
+                $('#priority-overview-filters').hide();
             }
 
             // Map route to Component Class & File
@@ -310,6 +323,21 @@ frappe.pages['project-dashboard'].on_page_load = function (wrapper) {
         // Re-apply filters when route changes
         frappe.router.on('change', () => {
             setTimeout(applyFilters, 100); // Give component time to render
+        });
+
+        // Priority Overview specific filters
+        $('#filter-company-priority').on('click', function() {
+            $(this).addClass('active').siblings().removeClass('active');
+            if (currentComponent && typeof currentComponent.set_view === 'function') {
+                currentComponent.set_view('company_priority');
+            }
+        });
+
+        $('#filter-value-stream').on('click', function() {
+            $(this).addClass('active').siblings().removeClass('active');
+            if (currentComponent && typeof currentComponent.set_view === 'function') {
+                currentComponent.set_view('value_stream');
+            }
         });
 
         // Dynamic Filter Add Logic

--- a/project_enhancements/public/js/dashboard_components/priority_overview.js
+++ b/project_enhancements/public/js/dashboard_components/priority_overview.js
@@ -4,6 +4,15 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
     constructor(wrapper) {
         this.wrapper = $(wrapper);
         this.abortController = null;
+        this.current_view = 'company_priority';
+        this.projects = [];
+    }
+
+    set_view(view) {
+        this.current_view = view;
+        if (this.projects && this.projects.length > 0) {
+            this.render_list_view(this.projects);
+        }
     }
 
     async render() {
@@ -29,14 +38,31 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
             if (signal.aborted) return;
 
             if (projects.message && !projects.message.error) {
-                const filteredProjects = projects.message.filter(p => p.is_active === 'Yes');
-                this.render_list_view(filteredProjects);
+                this.projects = projects.message.filter(p => p.is_active === 'Yes');
+                this.render_list_view(this.projects);
             } else {
                 throw new Error(projects.message ? projects.message.error : 'Unknown error fetching projects');
             }
         } finally {
             this.abortController = null;
         }
+    }
+
+    get_priority_weight(priority) {
+        if (!priority) return 100; // Empty/null treated as Not Assigned
+
+        let p = String(priority).trim();
+
+        if (p.toLowerCase() === 'not assigned') return 100;
+        if (p.toLowerCase() === 'repair visit') return 101;
+        if (p.toLowerCase() === 'maintenance') return 102;
+
+        let num = parseInt(p, 10);
+        if (!isNaN(num)) {
+            return num; // 1 to 30
+        }
+
+        return 200; // Unknown string values get pushed to the very bottom
     }
 
     render_list_view(projects) {
@@ -49,8 +75,61 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 
         const listContainer = $('<div class="frappe-list"></div>').appendTo(this.wrapper);
 
+        if (this.current_view === 'company_priority') {
+            // Sort by company priority
+            let sorted_projects = [...projects].sort((a, b) => {
+                let weightA = this.get_priority_weight(a.custom_company_priority);
+                let weightB = this.get_priority_weight(b.custom_company_priority);
+
+                if (weightA !== weightB) {
+                    return weightA - weightB;
+                }
+
+                // Fallback to alphabetical project name if priorities are same
+                let nameA = a.project_name || '';
+                let nameB = b.project_name || '';
+                return nameA.localeCompare(nameB);
+            });
+
+            this.render_table(listContainer, sorted_projects);
+        } else if (this.current_view === 'value_stream') {
+            // Group by project_type (Value Stream)
+            let groups = {};
+            projects.forEach(p => {
+                let stream = p.project_type || 'Uncategorized';
+                if (!groups[stream]) {
+                    groups[stream] = [];
+                }
+                groups[stream].push(p);
+            });
+
+            // Sort streams alphabetically
+            let sorted_streams = Object.keys(groups).sort((a, b) => a.localeCompare(b));
+
+            sorted_streams.forEach(stream => {
+                // Sort projects within stream by project priority
+                let stream_projects = groups[stream].sort((a, b) => {
+                    let weightA = this.get_priority_weight(a.custom_project_priority);
+                    let weightB = this.get_priority_weight(b.custom_project_priority);
+
+                    if (weightA !== weightB) {
+                        return weightA - weightB;
+                    }
+
+                    let nameA = a.project_name || '';
+                    let nameB = b.project_name || '';
+                    return nameA.localeCompare(nameB);
+                });
+
+                $(`<h5 class="mt-4 mb-3 text-muted border-bottom pb-2">${stream}</h5>`).appendTo(listContainer);
+                this.render_table(listContainer, stream_projects);
+            });
+        }
+    }
+
+    render_table(container, projects) {
         const table = $(`
-            <table class="table table-bordered table-hover">
+            <table class="table table-bordered table-hover mb-4">
                 <thead class="thead-light">
                     <tr>
                         <th>Project Name</th>
@@ -61,18 +140,25 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
                 </thead>
                 <tbody></tbody>
             </table>
-        `).appendTo(listContainer);
+        `).appendTo(container);
 
         const tbody = table.find('tbody');
         projects.forEach(p => {
             const row = $(`
                 <tr>
                     <td><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
-                    <td>${p.custom_project_priority || 'None'}</td>
-                    <td>${p.custom_company_priority || 'None'}</td>
+                    <td>${p.custom_project_priority || 'Not Assigned'}</td>
+                    <td>${p.custom_company_priority || 'Not Assigned'}</td>
                     <td><span class="badge ${this.get_status_badge(p.status)}">${p.status}</span></td>
                 </tr>
             `);
+
+            // Add data attributes to allow global search filtering
+            row.data('project_name', p.project_name);
+            row.data('custom_project_priority', p.custom_project_priority);
+            row.data('custom_company_priority', p.custom_company_priority);
+            row.data('status', p.status);
+
             tbody.append(row);
         });
     }


### PR DESCRIPTION
This pull request adds custom filtering and grouping functionality to the Priority Overview tab in the Project Dashboard.

Users can now toggle between two views:
1.  **Company Priority (Default):** A flat list of active projects, sorted by `custom_company_priority`.
2.  **Project Priority by Value Stream:** Projects are grouped by `project_type` (Value Stream), groups are sorted alphabetically, and projects within each group are sorted by `custom_project_priority`.

The sorting logic implements a specific hierarchy:
1.  Numerical values (1-30)
2.  "Not Assigned" (including null/empty values)
3.  "Repair Visit"
4.  "Maintenance"

The UI controls automatically hide when navigating away from the Priority Overview tab and their active states are reset upon returning to ensure synchronization with the default component state.

---
*PR created automatically by Jules for task [3104973027755432908](https://jules.google.com/task/3104973027755432908) started by @nbbshaw*