### PR TITLE
Fix indentation causing column misalignment in Task and Project Trees

### DIFF
--- a/project_enhancements/public/js/project_tree_manager.js
+++ b/project_enhancements/public/js/project_tree_manager.js
@@ -149,10 +149,12 @@ project_enhancements.ProjectTreeManager = class ProjectTreeManager {
             const node = $(`
                 <div class="task-node" data-task-id="${project.name}">
                     <div class="task-grid-row">
-                        <div class="task-grid-cell" style="padding-left: ${level * 20}px;">
-                            <i class="fa fa-bars task-drag-handle mr-2 text-muted" style="cursor: grab;"></i>
-                            <i class="fa fa-fw ${iconClass} mr-1" style="cursor: pointer;"></i>
-                            <a href="/app/project/${project.name}">${project.project_name || project.name}</a>
+                        <div class="task-grid-cell">
+                            <div style="padding-left: ${level * 20}px; display: flex; align-items: center; width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                                <i class="fa fa-bars task-drag-handle mr-2 text-muted" style="cursor: grab; flex-shrink: 0;"></i>
+                                <i class="fa fa-fw ${iconClass} mr-1" style="cursor: pointer; flex-shrink: 0;"></i>
+                                <a href="/app/project/${project.name}" style="overflow: hidden; text-overflow: ellipsis;">${project.project_name || project.name}</a>
+                            </div>
                         </div>
                         <div class="task-grid-cell assignee-cell"><a href="#" class="assignee-link">${project.assigned_to || 'Unassigned'}</a></div>
                         <div class="task-grid-cell">

--- a/project_enhancements/public/js/task_tree_manager.js
+++ b/project_enhancements/public/js/task_tree_manager.js
@@ -156,10 +156,12 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
             const node = $(`
                 <div class="task-node" data-task-id="${task.name}">
                     <div class="task-grid-row">
-                        <div class="task-grid-cell" style="padding-left: ${level * 20}px;">
-                            <i class="fa fa-bars task-drag-handle mr-2 text-muted" style="cursor: grab;"></i>
-                            <i class="fa fa-fw ${iconClass} mr-1" style="cursor: pointer;"></i>
-                            <a href="/app/task/${task.name}">${task.subject}</a>
+                        <div class="task-grid-cell">
+                            <div style="padding-left: ${level * 20}px; display: flex; align-items: center; width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                                <i class="fa fa-bars task-drag-handle mr-2 text-muted" style="cursor: grab; flex-shrink: 0;"></i>
+                                <i class="fa fa-fw ${iconClass} mr-1" style="cursor: pointer; flex-shrink: 0;"></i>
+                                <a href="/app/task/${task.name}" style="overflow: hidden; text-overflow: ellipsis;">${task.subject}</a>
+                            </div>
                         </div>
                         <div class="task-grid-cell assignee-cell"><a href="#" class="assignee-link">${task.assigned_to || 'Unassigned'}</a></div>
                         <div class="task-grid-cell">


### PR DESCRIPTION
Fixes a UI issue where nested tasks/projects in the tree view caused subsequent columns to shift to the right due to dynamic `padding-left` altering the flex basis of the first column. Introduced an inner wrapper to contain the padding.

---
*PR created automatically by Jules for task [12349078049407247574](https://jules.google.com/task/12349078049407247574) started by @nbbshaw*