### PR TITLE
fix: Align Tasks Tree columns vertically in Project DocType

### DIFF
--- a/project_enhancements/public/css/task_tree.css
+++ b/project_enhancements/public/css/task_tree.css
@@ -42,29 +42,43 @@
 }
 
 /* Specific column widths if needed */
-.task-grid-cell:nth-child(1) {
+/* Ensure min-width is set so cells shrink proportionally and don't blow out due to content */
+.task-grid-header > .task-grid-cell:nth-child(1),
+.task-grid-row > .task-grid-cell:nth-child(1) {
     flex: 3; /* Task Name / Project Name */
+    min-width: 0;
 }
 
-.task-grid-cell:nth-child(2) {
+.task-grid-header > .task-grid-cell:nth-child(2),
+.task-grid-row > .task-grid-cell:nth-child(2) {
     flex: 1.5; /* Owner */
+    min-width: 0;
 }
 
-.task-grid-cell:nth-child(3) {
+.task-grid-header > .task-grid-cell:nth-child(3),
+.task-grid-row > .task-grid-cell:nth-child(3) {
     flex: 1.5; /* Status */
+    min-width: 0;
 }
 
-.task-grid-cell:nth-child(4),
-.task-grid-cell:nth-child(5) {
+.task-grid-header > .task-grid-cell:nth-child(4),
+.task-grid-header > .task-grid-cell:nth-child(5),
+.task-grid-row > .task-grid-cell:nth-child(4),
+.task-grid-row > .task-grid-cell:nth-child(5) {
     flex: 1.5; /* Dates */
+    min-width: 0;
 }
 
-.task-grid-cell:nth-child(6) {
+.task-grid-header > .task-grid-cell:nth-child(6),
+.task-grid-row > .task-grid-cell:nth-child(6) {
     flex: 2; /* % Complete */
+    min-width: 0;
 }
 
-.task-grid-cell:nth-child(7) {
+.task-grid-header > .task-grid-cell:nth-child(7),
+.task-grid-row > .task-grid-cell:nth-child(7) {
     flex: 1; /* Duration (hrs) */
+    min-width: 0;
 }
 
 .task-grid-cell select.form-control {


### PR DESCRIPTION
Fixes vertical column misalignment in the Project DocType "Scope" tab (Tasks Tree HTML view). The generic flexbox properties were behaving inconsistently when nested inside `.task-node > .task-grid-row` vs `.task-grid-header` in the Frappe form view context. By increasing CSS selector specificity (e.g. `.task-grid-row > .task-grid-cell:nth-child(n)`) and adding `min-width: 0;`, column dimensions align uniformly between headers and rows while allowing flexbox children to scale properly down. The inner inline padding (`padding-left: ${level * 20}px`) on the Task Names correctly stays preserved as it is rendered inline by `task_tree_manager.js` to define hierarchical text indentation.

---
*PR created automatically by Jules for task [4315112275759118529](https://jules.google.com/task/4315112275759118529) started by @nbbshaw*