### PR TITLE
Refactor Project Dashboard Tabs and Navigation

### DIFF
--- a/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.js
+++ b/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.js
@@ -68,13 +68,13 @@ frappe.pages['project-dashboard'].on_page_load = function (wrapper) {
             <div class="dashboard-tabs p-3 pb-0 border-bottom">
                 <ul class="nav nav-tabs" role="tablist">
                     <li class="nav-item">
-                        <a class="nav-link" href="javascript:void(0)" data-route="active-external-projects">Active External Projects</a>
+                        <a class="nav-link" href="javascript:void(0)" data-route="priority-overview">Priority Overview</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="javascript:void(0)" data-route="active-internal-projects">Active Internal Projects</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="javascript:void(0)" data-route="priority-overview">Priority Overview</a>
+                        <a class="nav-link" href="javascript:void(0)" data-route="completed-projects">Completed Projects</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="javascript:void(0)" data-route="portfolio-gantt">Portfolio Gantt</a>
@@ -107,7 +107,7 @@ frappe.pages['project-dashboard'].on_page_load = function (wrapper) {
                         </button>
                         <div id="priority-overview-filters" style="display: none;" class="ml-2 btn-group btn-group-sm">
                             <button type="button" class="btn btn-default active" id="filter-company-priority">Company Priority</button>
-                            <button type="button" class="btn btn-default" id="filter-value-stream">Project Priority by Value Stream</button>
+                            <button type="button" class="btn btn-default" id="filter-value-stream">By Value Stream</button>
                         </div>
                     </div>
                     <div class="col-md-4 text-right">
@@ -134,7 +134,10 @@ frappe.pages['project-dashboard'].on_page_load = function (wrapper) {
             const route = frappe.get_route();
             if (route[0] !== 'project-dashboard') return;
 
-            const moduleRoute = route[1] || 'active-external-projects';
+            const moduleRoute = route[1] || localStorage.getItem('project_dashboard_default_tab') || 'priority-overview';
+
+            // Save active tab preference
+            localStorage.setItem('project_dashboard_default_tab', moduleRoute);
             const componentArgs = route.slice(2);
 
             // Update Tab Active State
@@ -161,12 +164,6 @@ frappe.pages['project-dashboard'].on_page_load = function (wrapper) {
             // Map route to Component Class & File
             let componentConfig;
             switch (moduleRoute) {
-                case 'active-external-projects':
-                    componentConfig = {
-                        file: '/assets/project_enhancements/js/dashboard_components/active_external_projects.js',
-                        className: 'ActiveExternalProjects'
-                    };
-                    break;
                 case 'active-internal-projects':
                     componentConfig = {
                         file: '/assets/project_enhancements/js/dashboard_components/active_internal_projects.js',
@@ -191,9 +188,15 @@ frappe.pages['project-dashboard'].on_page_load = function (wrapper) {
                         className: 'TasksTree'
                     };
                     break;
+                case 'completed-projects':
+                    componentConfig = {
+                        file: '/assets/project_enhancements/js/dashboard_components/completed_projects.js',
+                        className: 'CompletedProjects'
+                    };
+                    break;
                 default:
-                    // Fallback to active external
-                    frappe.set_route('project-dashboard', 'active-external-projects');
+                    // Fallback to priority overview
+                    frappe.set_route('project-dashboard', 'priority-overview');
                     return;
             }
 
@@ -440,8 +443,9 @@ frappe.pages['project-dashboard'].on_page_load = function (wrapper) {
         // Initial render logic
         const currentRoute = frappe.get_route();
         if (currentRoute.length === 1 && currentRoute[0] === 'project-dashboard') {
-            // No sub-route, default to external projects
-            frappe.set_route('project-dashboard', 'active-external-projects');
+            // No sub-route, default to priority overview or local storage preference
+            const defaultTab = localStorage.getItem('project_dashboard_default_tab') || 'priority-overview';
+            frappe.set_route('project-dashboard', defaultTab);
         } else {
             // Trigger route logic for current route
             handleRouteChange();

--- a/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.py
+++ b/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.py
@@ -90,12 +90,15 @@ def _get_assignee_names(doctype, docname):
 
 
 @frappe.whitelist()
-def get_project_data():
+def get_project_data(is_active=None):
     """Fetches and enriches project data for the dashboard.
 
     Retrieves all non-cancelled projects and annotates each with task counts
     (total and completed) and the names of assigned users. It first checks if
     the user has permission to view the dashboard.
+
+    Args:
+        is_active (str, optional): Filter by 'is_active' status ('Yes' or 'No').
 
     Returns:
         list[dict] | dict: A list of project dictionaries, each enhanced with
@@ -108,6 +111,10 @@ def get_project_data():
         if not check_permission():
             # Using dict for consistency in error handling on the client-side
             return {"error": "You do not have permission to view the Project Dashboard."}
+
+        filters = {"status": ["!=", "Cancelled"]}
+        if is_active:
+            filters["is_active"] = is_active
 
         projects = frappe.get_list(
             "Project",
@@ -124,7 +131,7 @@ def get_project_data():
                 "expected_start_date",
                 "expected_end_date",
             ],
-            filters={"status": ["!=", "Cancelled"]},
+            filters=filters,
             order_by="creation desc",
         )
 

--- a/project_enhancements/public/js/dashboard_components/active_internal_projects.js
+++ b/project_enhancements/public/js/dashboard_components/active_internal_projects.js
@@ -76,7 +76,7 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
 
             const row = $(`
                 <tr data-project="${p.name}">
-                    <td><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
+                    <td><a href="/app/project/${p.name}?view=custom_scope&origin=dashboard" class="font-weight-bold">${p.project_name}</a></td>
                     <td><select class="form-control form-control-sm project-edit" data-field="status">${statusSelect}</select></td>
                     <td><select class="form-control form-control-sm project-edit" data-field="custom_project_priority">${prioritySelect}</select></td>
                     <td>

--- a/project_enhancements/public/js/dashboard_components/completed_projects.js
+++ b/project_enhancements/public/js/dashboard_components/completed_projects.js
@@ -1,6 +1,6 @@
 frappe.provide('project_enhancements.dashboard_components');
 
-project_enhancements.dashboard_components.ActiveExternalProjects = class ActiveExternalProjects {
+project_enhancements.dashboard_components.CompletedProjects = class CompletedProjects {
     constructor(wrapper) {
         this.wrapper = $(wrapper);
         this.abortController = null;
@@ -17,27 +17,52 @@ project_enhancements.dashboard_components.ActiveExternalProjects = class ActiveE
         }
     }
 
-    async fetch_and_render_data() {
+    async fetch_and_render_data(attempt = 1) {
         this.abortController = new AbortController();
         const signal = this.abortController.signal;
 
         try {
             const projects = await project_enhancements.dashboard_api.call({
-                method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.get_project_data"
+                method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.get_project_data",
+                args: {
+                    is_active: 'No'
+                }
             }, signal);
 
             if (signal.aborted) return;
 
             if (projects.message && !projects.message.error) {
-                const allowedTypes = ["External", "Design", "Build", "Service", "Rent"];
-                const filteredProjects = projects.message.filter(p => p.is_active === 'Yes' && allowedTypes.includes(p.project_type));
-
-                this.render_list_view(filteredProjects);
+                this.render_list_view(projects.message);
             } else {
-                throw new Error(projects.message ? projects.message.error : 'Unknown error fetching projects');
+                throw new Error(projects.message ? projects.message.error : 'Unknown error fetching completed projects');
+            }
+        } catch (error) {
+            if (error.name === 'CancellationError') {
+                return;
+            }
+
+            // Exponential backoff logic for retries
+            const maxRetries = 3;
+            if (attempt <= maxRetries && (error.name === 'TimeoutError' || error.message.includes('fetch'))) {
+                console.warn(`Attempt ${attempt} failed. Retrying in ${Math.pow(2, attempt)} seconds...`);
+                this.wrapper.html(`
+                    <div class="alert alert-warning p-4 text-center">
+                        <p><i class="fa fa-spinner fa-spin mr-2"></i> Retrying data fetch (Attempt ${attempt}/${maxRetries})...</p>
+                    </div>
+                `);
+
+                await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+
+                if (signal.aborted) return;
+
+                return this.fetch_and_render_data(attempt + 1);
+            } else {
+                this.handle_error(error);
             }
         } finally {
-            this.abortController = null;
+            if (this.abortController && this.abortController.signal === signal) {
+                this.abortController = null;
+            }
         }
     }
 
@@ -45,21 +70,19 @@ project_enhancements.dashboard_components.ActiveExternalProjects = class ActiveE
         this.wrapper.empty();
 
         if (!projects || projects.length === 0) {
-            this.wrapper.html('<p class="text-muted text-center p-4">No active external projects found.</p>');
+            this.wrapper.html('<p class="text-muted text-center p-4">No completed projects found.</p>');
             return;
         }
 
         const listContainer = $('<div class="frappe-list"></div>').appendTo(this.wrapper);
 
-        // Use standard frappe UI List View layout approach
         const table = $(`
             <table class="table table-bordered table-hover">
                 <thead class="thead-light">
                     <tr>
                         <th>Project Name</th>
                         <th>Status</th>
-                        <th>Priority</th>
-                        <th>% Complete</th>
+                        <th>Type</th>
                         <th>Assigned To</th>
                     </tr>
                 </thead>
@@ -68,23 +91,13 @@ project_enhancements.dashboard_components.ActiveExternalProjects = class ActiveE
         `).appendTo(listContainer);
 
         const tbody = table.find('tbody');
-        const statusOptions = ['Active', 'On Hold', 'Canceled', 'Completed', 'Invoiced'];
-        const priorityOptions = ['High', 'Medium', 'Low'];
 
         projects.forEach(p => {
-            const statusSelect = statusOptions.map(s => `<option value="${s}" ${p.status === s ? 'selected' : ''}>${s}</option>`).join('');
-            const prioritySelect = priorityOptions.map(pr => `<option value="${pr}" ${p.custom_project_priority === pr ? 'selected' : ''}>${pr}</option>`).join('');
-
             const row = $(`
                 <tr data-project="${p.name}">
-                    <td><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
-                    <td><select class="form-control form-control-sm project-edit" data-field="status">${statusSelect}</select></td>
-                    <td><select class="form-control form-control-sm project-edit" data-field="custom_project_priority">${prioritySelect}</select></td>
-                    <td>
-                        <div class="progress" style="height: 10px; border-radius: 4px;">
-                            <div class="progress-bar bg-primary" role="progressbar" style="width: ${p.percent_complete || 0}%" aria-valuenow="${p.percent_complete || 0}" aria-valuemin="0" aria-valuemax="100"></div>
-                        </div>
-                    </td>
+                    <td><a href="/app/project/${p.name}?view=custom_scope&origin=dashboard" class="font-weight-bold">${p.project_name}</a></td>
+                    <td><span class="badge ${this.get_status_badge(p.status)}">${p.status}</span></td>
+                    <td>${p.project_type || 'Uncategorized'}</td>
                     <td class="text-muted">${p.project_user || 'Unassigned'}</td>
                 </tr>
             `);
@@ -95,21 +108,6 @@ project_enhancements.dashboard_components.ActiveExternalProjects = class ActiveE
             });
 
             tbody.append(row);
-        });
-
-        // Trigger global event on edit
-        this.wrapper.find('.project-edit').on('change', (e) => {
-            const el = $(e.target);
-            const project = el.closest('tr').data('project');
-            const field = el.data('field');
-            const val = el.val();
-
-            // Dispatch a custom event to the document so the main controller can pick it up
-            $(document).trigger('dashboard_project_change', {
-                project: project,
-                field: field,
-                value: val
-            });
         });
     }
 
@@ -138,15 +136,15 @@ project_enhancements.dashboard_components.ActiveExternalProjects = class ActiveE
 
     handle_error(error) {
         if (error.name === 'CancellationError') {
-            console.log('Active External Projects request aborted due to context switch.');
+            console.log('Completed Projects request aborted due to context switch.');
             return;
         }
 
-        console.error('Active External Projects Error:', error);
+        console.error('Completed Projects Error:', error);
 
         this.wrapper.html(`
             <div class="alert alert-danger p-4 text-center">
-                <h4><i class="fa fa-exclamation-triangle mr-2"></i> Failed to Load Data</h4>
+                <h4><i class="fa fa-exclamation-triangle mr-2"></i> Service Unavailable</h4>
                 <p>${error.message || 'An unexpected error occurred.'}</p>
                 <button class="btn btn-primary btn-sm mt-3 retry-btn">Retry</button>
             </div>

--- a/project_enhancements/public/js/dashboard_components/priority_overview.js
+++ b/project_enhancements/public/js/dashboard_components/priority_overview.js
@@ -146,7 +146,7 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
         projects.forEach(p => {
             const row = $(`
                 <tr>
-                    <td><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
+                    <td><a href="/app/project/${p.name}?view=custom_scope&origin=dashboard" class="font-weight-bold">${p.project_name}</a></td>
                     <td>${this.get_priority_badge(p.custom_project_priority)}</td>
                     <td>${this.get_priority_badge(p.custom_company_priority)}</td>
                     <td><span class="badge ${this.get_status_badge(p.status)}">${p.status}</span></td>

--- a/project_enhancements/public/js/dashboard_components/tasks_tree.js
+++ b/project_enhancements/public/js/dashboard_components/tasks_tree.js
@@ -75,7 +75,7 @@ project_enhancements.dashboard_components.TasksTree = class TasksTree {
         projects.forEach(p => {
             const row = $(`
                 <tr>
-                    <td><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
+                    <td><a href="/app/project/${p.name}?view=custom_scope&origin=dashboard" class="font-weight-bold">${p.project_name}</a></td>
                     <td><button class="btn btn-primary btn-sm view-tasks-btn" data-project="${p.name}">View Tasks</button></td>
                 </tr>
             `);

--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -47,5 +47,22 @@ frappe.ui.form.on('Project', {
                 console.warn("Project Enhancements: TaskTreeManager class not found. Ensure task_tree_manager.js is loaded.");
             }
         }
+
+        // Deep linking logic from Dashboard
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.get('origin') === 'dashboard' && urlParams.get('view') === 'custom_scope') {
+            // Wait for standard form initialization to complete
+            setTimeout(() => {
+                const scopeTab = formTabs.find('.nav-item[data-label="Scope"], .nav-item[data-fieldname="custom_scope"]');
+                if (scopeTab.length) {
+                    const tabLink = scopeTab.find('a.nav-link');
+                    if (tabLink.length) {
+                        tabLink.click();
+                    } else {
+                        scopeTab.click();
+                    }
+                }
+            }, 300);
+        }
     }
 });


### PR DESCRIPTION
- Removes `active-external-projects` component and tab from the UI.
- Adds `completed_projects.js` which loads an optimized `is_active=No` subset from the backend.
- Sets the default view to `priority-overview` (Company Priority) instead of the removed tab, utilizing `localStorage` to cache the user's selected tab state.
- Adjusts the "Project Priority by Value Stream" label string to "By Value Stream".
- All internal project routing now passes `?view=custom_scope&origin=dashboard` parameters. `project_form_script.js` intercepts these parameters and automatically navigates the form view to the `Scope` tab.

---
*PR created automatically by Jules for task [15081647226917136161](https://jules.google.com/task/15081647226917136161) started by @nbbshaw*