### PR TITLE
Fix doctype JS paths in hooks.py

### DIFF
--- a/project_enhancements/hooks.py
+++ b/project_enhancements/hooks.py
@@ -34,10 +34,10 @@ app_license = "mit"
 # on the Project doctype's form view. The path is relative to the app's root.
 
 doctype_js = {
-	"Project": ["project_enhancements/doctype/project/project.js", "public/js/project_form_script.js"],
+	"Project": ["project_enhancements/doctype/project/project.js", "project_enhancements/public/js/project_form_script.js"],
 	"Opportunity": "project_enhancements/doctype/opportunity/opportunity.js",
 	"Address": "project_enhancements/doctype/address/address.js",
-	"Master Project": ["public/js/master_project_form_script.js"]
+	"Master Project": ["project_enhancements/public/js/master_project_form_script.js"]
 }
 
 # ------------------
@@ -100,7 +100,7 @@ app_include_js = [
 # include js in doctype views
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 doctype_list_js = {
-    "Task": "public/js/task_gantt.js"
+    "Task": "project_enhancements/public/js/task_gantt.js"
 }
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}


### PR DESCRIPTION
This commit fixes a bug where the custom JavaScript intended for the "Master Project" DocType wasn't loading on the frontend. This was caused by an incorrect file path mapping in `hooks.py`. In Frappe, asset paths specified in hooks like `doctype_js` must be prefixed with the application name to be correctly resolved and served. 

I updated the path for the `Master Project` script and proactively did the same for the `Project` and `Task` scripts, which had the exact same misconfiguration.

---
*PR created automatically by Jules for task [8059155403825529209](https://jules.google.com/task/8059155403825529209) started by @parker-bailey*