### PR TITLE
Add debug alerts to master project form

### DIFF
--- a/project_enhancements/public/js/master_project_form_script.js
+++ b/project_enhancements/public/js/master_project_form_script.js
@@ -6,9 +6,13 @@ frappe.ui.form.on('Master Project', {
     // The 'refresh' trigger ensures our script runs every time the form is loaded or refreshed.
     onload: function(frm) {
         console.log("Master Project form 'onload' triggered.");
+        console.error("Code is working");
+        alert("Code is working");
     },
     refresh: function(frm) {
         console.log("Master Project form 'refresh' triggered.");
+        console.error("Code is working");
+        alert("Code is working");
 
         // Target the custom 'project_list' HTML field
         const targetField = frm.fields_dict['project_list'];


### PR DESCRIPTION
This pull request adds debugging alerts to the `Master Project` form script to verify it is correctly loaded and executed by the Frappe framework.

Changes:
- Modified `project_enhancements/public/js/master_project_form_script.js`.
- Inserted `console.error("Code is working")` and `alert("Code is working")` in both the `onload` and `refresh` form handlers for the "Master Project" DocType.

---
*PR created automatically by Jules for task [18370165391816929402](https://jules.google.com/task/18370165391816929402) started by @parker-bailey*