### PR TITLE
fix: Task Tree rendering and View Tasks button routing

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -79,5 +79,17 @@ frappe.ui.form.on('Project', {
 
         // Check when hash changes (e.g. Back/Forward navigation)
         $(window).on('hashchange', checkAndSwitchToScopeTab);
+
+        // Add 'View Tasks' Custom Button
+        if (!frm.is_new()) {
+            setTimeout(() => {
+                frm.remove_custom_button(__('View Tasks')); // Remove if exists to avoid duplicates
+
+                frm.add_custom_button(__('View Tasks'), function() {
+                    // Cleaner navigation method to the specific project task tree
+                    frappe.set_route('project-dashboard', 'tasks-tree', frm.doc.name);
+                }).addClass('btn-primary');
+            }, 10);
+        }
     }
 });

--- a/project_enhancements/public/js/task_tree_manager.js
+++ b/project_enhancements/public/js/task_tree_manager.js
@@ -90,7 +90,13 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
         // Fallback to standard frappe.call if dashboard_api is not available (e.g. on Task form view)
         const callApi = window.project_enhancements && project_enhancements.dashboard_api
             ? project_enhancements.dashboard_api.call
-            : frappe.call;
+            : (options) => new Promise((resolve, reject) => {
+                frappe.call({
+                    ...options,
+                    callback: resolve,
+                    error: reject
+                });
+            });
 
         const fetchStatusOptions = callApi({
             method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.get_task_status_options"


### PR DESCRIPTION
Fixes a bug where the Task Tree failed to render in the Project Form view due to a promise resolution conflict with the native `frappe.call`. Also incorporates the custom "View Tasks" client script into the codebase, routing correctly to the specific project's Task Tree rather than the dashboard default page.

---
*PR created automatically by Jules for task [11768931817658367461](https://jules.google.com/task/11768931817658367461) started by @nbbshaw*