### PR TITLE
Add Master Project link field and synchronization logic to Project

### DIFF
--- a/project_enhancements/fixtures/custom_field.json
+++ b/project_enhancements/fixtures/custom_field.json
@@ -99,5 +99,15 @@
   "fieldtype": "HTML",
   "label": "Project Tree View",
   "name": "Master Project-task_tree_view"
+ },
+ {
+  "doctype": "Custom Field",
+  "dt": "Project",
+  "fieldname": "custom_master_project",
+  "fieldtype": "Link",
+  "options": "Master Project",
+  "label": "Master Project",
+  "insert_after": "project_name",
+  "name": "Project-custom_master_project"
  }
 ]

--- a/project_enhancements/hooks.py
+++ b/project_enhancements/hooks.py
@@ -202,6 +202,9 @@ doc_events = {
 	"Master Project": {
 		"validate": "project_enhancements.project_enhancements.master_project.trigger_server_side",
 		"on_update": "project_enhancements.project_enhancements.master_project.trigger_server_side"
+	},
+	"Project": {
+		"on_update": "project_enhancements.project_enhancements.doctype.project.project.sync_master_project"
 	}
 }
 

--- a/project_enhancements/project_enhancements/doctype/project/project.py
+++ b/project_enhancements/project_enhancements/doctype/project/project.py
@@ -28,3 +28,39 @@ def get_project_grouping_option():
 
     # This sends the `settings` dictionary back to the browser as the response.
     return settings
+def sync_master_project(doc, method=None):
+    """
+    Syncs the Project with the corresponding Master Project child table 'projects'.
+    If custom_master_project is set, adds this project to the Master Project.
+    If custom_master_project was changed, removes this project from the old Master Project.
+    """
+
+    # We use get_doc_before_save to find out if the custom_master_project changed
+    doc_before_save = doc.get_doc_before_save()
+    old_master_project = doc_before_save.custom_master_project if doc_before_save else None
+    new_master_project = doc.custom_master_project
+
+    # If the master project didn't change, there's nothing to do
+    if old_master_project == new_master_project:
+        return
+
+    # Remove from old Master Project if it existed
+    if old_master_project:
+        try:
+            old_mp_doc = frappe.get_doc("Master Project", old_master_project)
+            # Find the row in the child table where project is this doc
+            rows_to_remove = [row for row in old_mp_doc.projects if row.project == doc.name]
+            if rows_to_remove:
+                for row in rows_to_remove:
+                    old_mp_doc.remove(row)
+                old_mp_doc.save(ignore_permissions=True)
+        except frappe.DoesNotExistError:
+            pass # Old Master Project was deleted
+
+    # Add to new Master Project if one is selected
+    if new_master_project:
+        new_mp_doc = frappe.get_doc("Master Project", new_master_project)
+        # Only add if it's not already in the table
+        if not any(row.project == doc.name for row in new_mp_doc.projects):
+            new_mp_doc.append("projects", {"project": doc.name})
+            new_mp_doc.save(ignore_permissions=True)


### PR DESCRIPTION
Added the Master Project link field to the Project doctype. Implemented a server-side Python hook that automatically adds the Project to the Master Project's `projects` child table when selected, and removes it from the old Master Project if reassigned.

---
*PR created automatically by Jules for task [17635704061348989173](https://jules.google.com/task/17635704061348989173) started by @parker-bailey*