### PR TITLE
Fix View Tasks Button Rendering and Routing

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -83,12 +83,26 @@ frappe.ui.form.on('Project', {
         // Add 'View Tasks' Custom Button
         if (!frm.is_new()) {
             setTimeout(() => {
-                frm.remove_custom_button(__('View Tasks')); // Remove if exists to avoid duplicates
+                // Ensure the button isn't duplicated
+                if (frm.page.get_menu_item(__('View Tasks'))) {
+                    frm.page.remove_menu_item(__('View Tasks'));
+                }
+                if (frm.page.get_inner_group_button(__('View Tasks'))) {
+                    frm.page.remove_inner_button(__('View Tasks'));
+                }
 
-                frm.add_custom_button(__('View Tasks'), function() {
-                    // Cleaner navigation method to the specific project task tree
+                // Add the primary button next to 'Merge Project' / 'Actions'
+                let btn = frm.page.add_button(__('View Tasks'), function() {
+                    // Navigate to the specific project task tree in the dashboard
                     frappe.set_route('project-dashboard', 'tasks-tree', frm.doc.name);
-                }).addClass('btn-primary');
+                });
+
+                // Style as primary button
+                if (btn) {
+                    btn.addClass('btn-primary');
+                    // Add an icon to visually distinguish the action
+                    btn.html(`<svg class="icon icon-sm"><use href="#icon-node-tree"></use></svg> <span class="hidden-xs">${__('View Tasks')}</span>`);
+                }
             }, 10);
         }
     }


### PR DESCRIPTION
Fixes the "View Tasks" button in the Project DocType.

The original implementation used `frm.add_custom_button`, which places the button under the "Actions" or "..." secondary menus depending on Frappe's mood and screen size. The user wanted a visible Primary button placed next to standard header actions like "Merge Project".

This patch:
1. Replaces `frm.add_custom_button` with `frm.page.add_button` for explicit placement in the page actions header.
2. Adds `.addClass('btn-primary')` to make it visually stand out as a primary action.
3. Includes an SVG icon to distinguish the action visually.
4. Correctly triggers the requested URL navigation to `/app/project-dashboard/tasks-tree/<project-name>` via Frappe's native SPA router `frappe.set_route('project-dashboard', 'tasks-tree', frm.doc.name)`.

---
*PR created automatically by Jules for task [7993694510009665873](https://jules.google.com/task/7993694510009665873) started by @nbbshaw*