### PR TITLE
Fix Task Tree rendering issue on Project form

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -39,18 +39,13 @@ frappe.ui.form.on('Project', {
         if (frm.fields_dict['custom_tasks_html']) {
             // Check if the global namespace and class exist
             if (window.project_enhancements && project_enhancements.TaskTreeManager) {
-                // If the instance already exists for a different project, destroy/remove it
-                if (frm.task_tree_instance && frm.task_tree_instance.projectName !== frm.doc.name) {
-                    frm.get_field('custom_tasks_html').$wrapper.empty();
-                    frm.task_tree_instance = null;
-                }
-
-                if (!frm.task_tree_instance) {
-                    frm.task_tree_instance = new project_enhancements.TaskTreeManager({
-                        wrapper: frm.get_field('custom_tasks_html').$wrapper,
-                        projectName: frm.doc.name
-                    });
-                }
+                // Always recreate the instance to ensure it binds to the new DOM wrapper
+                // that Frappe might have generated on refresh
+                frm.get_field('custom_tasks_html').$wrapper.empty();
+                frm.task_tree_instance = new project_enhancements.TaskTreeManager({
+                    wrapper: frm.get_field('custom_tasks_html').$wrapper,
+                    projectName: frm.doc.name
+                });
             } else {
                 console.warn("Project Enhancements: TaskTreeManager class not found. Ensure task_tree_manager.js is loaded.");
             }


### PR DESCRIPTION
The Task Tree was not rendering at all on the Project Form because the `TaskTreeManager` instance was retaining a reference to a stale DOM wrapper. This fixes it by unconditionally recreating the instance on `refresh` so it binds correctly to the new wrapper Frappe generates.

---
*PR created automatically by Jules for task [2703768846383849152](https://jules.google.com/task/2703768846383849152) started by @nbbshaw*