### PR TITLE
fix: lowercase project in set_route for view tasks button

### DIFF
--- a/project_enhancements/public/js/dashboard_components/tasks_tree.js
+++ b/project_enhancements/public/js/dashboard_components/tasks_tree.js
@@ -87,7 +87,7 @@ project_enhancements.dashboard_components.TasksTree = class TasksTree {
             const projectName = $(e.currentTarget).data('project');
             try {
                 // Await the routing transition to the Project form
-                await frappe.set_route('Project', projectName);
+                await frappe.set_route('project', projectName);
                 // Once the promise resolves, assert the state
                 window.location.hash = '#custom_scope';
             } catch (error) {


### PR DESCRIPTION
Fixes a routing issue on the Tasks Tree tab of the Project Dashboard. Clicking the "View Tasks" button caused an error: "Page Project not found" because `frappe.set_route` was trying to navigate to `/Project/...` instead of the expected `/project/...`. Changed the case to lowercase.

---
*PR created automatically by Jules for task [8999086570364122535](https://jules.google.com/task/8999086570364122535) started by @nbbshaw*