### PR TITLE
Fix missing View custom buttons in Project form

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -86,9 +86,8 @@ frappe.ui.form.on('Project', {
                 }
 
                 // 1. Calendar View Handler
-                frm.page.add_inner_button(__('Calendar View'), async function() {
-                    const dropdownBtn = frm.page.wrapper.find('.inner-group-button[data-label="View"]');
-                    dropdownBtn.prop('disabled', true);
+                frm.add_custom_button(__('Calendar View'), async function() {
+                    frappe.dom.freeze(__('Navigating to Calendar View...'));
 
                     try {
                         frappe.route_options = { project: frm.doc.name };
@@ -97,14 +96,13 @@ frappe.ui.form.on('Project', {
                         console.error('Routing failed:', error);
                         frappe.show_alert({ message: __('Failed to navigate to Calendar View.'), indicator: 'red' });
                     } finally {
-                        dropdownBtn.prop('disabled', false);
+                        frappe.dom.unfreeze();
                     }
                 }, __('View'));
 
                 // 2. Custom Tree View Handler
-                frm.page.add_inner_button(__('Tree View'), async function() {
-                    const dropdownBtn = frm.page.wrapper.find('.inner-group-button[data-label="View"]');
-                    dropdownBtn.prop('disabled', true);
+                frm.add_custom_button(__('Tree View'), async function() {
+                    frappe.dom.freeze(__('Loading Tree View...'));
 
                     try {
                         window.location.hash = '#custom_scope';
@@ -149,7 +147,7 @@ frappe.ui.form.on('Project', {
                         console.error('Tree View loading failed:', error);
                         frappe.show_alert({ message: __('Failed to load Tree View.'), indicator: 'red' });
                     } finally {
-                        dropdownBtn.prop('disabled', false);
+                        frappe.dom.unfreeze();
                     }
                 }, __('View'));
 


### PR DESCRIPTION
The 'Calendar View' and 'Tree View' buttons were originally set using `frm.page.add_inner_button(..., __('View'))`. In standard Frappe form pages, the "View" menu containing Gantt Chart and Kanban Board is actually a custom dropdown button created with `frm.add_custom_button`, not an inner toolbar group. Consequently, the buttons failed to merge and appear inside that specific top-bar "View" dropdown.

To resolve this:
- Changed `frm.page.add_inner_button(..., __('View'))` to `frm.add_custom_button(..., __('View'))` for both "Calendar View" and "Tree View" so that they slot exactly into the main form actions "View" dropdown.
- Discarded flawed jQuery button disabling logic that assumed the button was an inner-group member (`.inner-group-button[data-label="View"]`). Replaced it with native, robust `frappe.dom.freeze()` and `frappe.dom.unfreeze()` calls which block interaction smoothly during page routing and script loading.

---
*PR created automatically by Jules for task [8077205181028007731](https://jules.google.com/task/8077205181028007731) started by @nbbshaw*