### PR TITLE
Fix project dashboard link routing

### DIFF
--- a/project_enhancements/public/js/dashboard_components/active_internal_projects.js
+++ b/project_enhancements/public/js/dashboard_components/active_internal_projects.js
@@ -77,7 +77,7 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
 
             const row = $(`
                 <tr data-project="${p.name}">
-                    <td><a href="/app/project/${p.name}?view=custom_scope&origin=dashboard" class="font-weight-bold">${p.project_name}</a></td>
+                    <td><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
                     <td><select class="form-control form-control-sm project-edit" data-field="status">${statusSelect}</select></td>
                     <td><select class="form-control form-control-sm project-edit" data-field="custom_project_priority">${prioritySelect}</select></td>
                     <td>

--- a/project_enhancements/public/js/dashboard_components/completed_projects.js
+++ b/project_enhancements/public/js/dashboard_components/completed_projects.js
@@ -96,7 +96,7 @@ project_enhancements.dashboard_components.CompletedProjects = class CompletedPro
         projects.forEach(p => {
             const row = $(`
                 <tr data-project="${p.name}">
-                    <td><a href="/app/project/${p.name}?view=custom_scope&origin=dashboard" class="font-weight-bold">${p.project_name}</a></td>
+                    <td><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
                     <td><span class="badge ${this.get_status_badge(p.status)}">${p.status}</span></td>
                     <td>${p.project_type || 'Uncategorized'}</td>
                     <td class="text-muted">${p.project_user || 'Unassigned'}</td>

--- a/project_enhancements/public/js/dashboard_components/priority_overview.js
+++ b/project_enhancements/public/js/dashboard_components/priority_overview.js
@@ -330,7 +330,7 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 
             const row = $(`
                 <tr>
-                    <td><a href="/app/project/${p.name}#custom_scope" class="font-weight-bold project-link" data-name="${p.name}">${p.project_name}</a></td>
+                    <td><a href="/app/project/${p.name}" class="font-weight-bold project-link" data-name="${p.name}">${p.project_name}</a></td>
                     <td class="editable-cell priority-cell" data-field="custom_company_priority" data-project="${p.name}">
                         <div class="static-view" style="cursor: pointer;" title="Click to edit">
                             ${this.get_priority_badge(display_company_priority)}
@@ -353,9 +353,7 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 
             row.find('.project-link').on('click', (e) => {
                 e.preventDefault();
-                frappe.set_route('project', p.name).then(() => {
-                    window.location.hash = 'custom_scope';
-                });
+                frappe.set_route('project', p.name);
             });
 
             // Initialize inline editing functionality

--- a/project_enhancements/public/js/dashboard_components/tasks_view.js
+++ b/project_enhancements/public/js/dashboard_components/tasks_view.js
@@ -155,7 +155,7 @@ project_enhancements.dashboard_components.TasksView = class TasksView {
         projects.forEach(p => {
             const row = $(`
                 <tr>
-                    <td><a href="/app/project/${p.name}?view=custom_scope&origin=dashboard" class="font-weight-bold">${p.project_name}</a></td>
+                    <td><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
                     <td><button class="btn btn-primary btn-sm view-tasks-btn" data-project="${p.name}">View Tasks</button></td>
                 </tr>
             `);


### PR DESCRIPTION
This PR updates the routing behavior for Project document links within the Projects Dashboard. Previously, all project links routed specifically to the "Scope" tab (`#custom_scope`). Now, only the "View Tasks" button in the Tasks View tab retains this behavior, while all other standard project links correctly route to the default first tab of the Project form.

---
*PR created automatically by Jules for task [9585020472493217630](https://jules.google.com/task/9585020472493217630) started by @nbbshaw*