### PR TITLE
fix(dashboard): dynamically fetch company and project priority options

### DIFF
--- a/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.py
+++ b/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.py
@@ -269,29 +269,33 @@ def update_task_status(task_name, status):
 
 @frappe.whitelist()
 def get_priority_options():
-    """Retrieves 'custom_project_priority' options from Project DocType.
+    """Retrieves 'custom_project_priority' and 'custom_company_priority' options from Project DocType.
 
-    Reads the options for the 'custom_project_priority' field directly from
+    Reads the options for the priority fields directly from
     the Project DocType's metadata.
 
     Returns:
-        list[str] | dict: A list of available priority options. Returns a
+        dict: A dictionary containing available priority options. Returns a
             dictionary with an 'error' key on failure.
     """
     try:
         project_doctype = frappe.get_meta("Project")
-        priority_field = next(
+        project_priority_field = next(
             (df for df in project_doctype.fields if df.fieldname == "custom_project_priority"), None
         )
+        company_priority_field = next(
+            (df for df in project_doctype.fields if df.fieldname == "custom_company_priority"), None
+        )
 
-        if priority_field and priority_field.options:
-            # Options are stored as a string, separated by newlines.
-            # We also filter out any empty lines that might result from trailing newlines.
-            options = [opt for opt in priority_field.options.split("\n") if opt]
-            return options
-        else:
-            # Return a default list or an empty list if no options are found
-            return []
+        options = {"project_priority": [], "company_priority": []}
+
+        if project_priority_field and project_priority_field.options:
+            options["project_priority"] = [opt for opt in project_priority_field.options.split("\n") if opt]
+
+        if company_priority_field and company_priority_field.options:
+            options["company_priority"] = [opt for opt in company_priority_field.options.split("\n") if opt]
+
+        return options
 
     except Exception as e:
         frappe.log_error(frappe.get_traceback(), "Error fetching priority options")

--- a/project_enhancements/project_enhancements/page/project_dashboard/test_project_dashboard.py
+++ b/project_enhancements/project_enhancements/page/project_dashboard/test_project_dashboard.py
@@ -168,10 +168,11 @@ class TestProjectDashboard(unittest.TestCase):
         """Test successful retrieval of priority options."""
         mock_meta = mock_get_meta.return_value
         mock_meta.fields = [
-            frappe._dict({"fieldname": "custom_project_priority", "options": "High\nMedium\nLow"})
+            frappe._dict({"fieldname": "custom_project_priority", "options": "High\nMedium\nLow"}),
+            frappe._dict({"fieldname": "custom_company_priority", "options": "1\n2\n3"})
         ]
         result = get_priority_options()
-        self.assertEqual(result, ["High", "Medium", "Low"])
+        self.assertEqual(result, {"project_priority": ["High", "Medium", "Low"], "company_priority": ["1", "2", "3"]})
 
     @patch("project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.frappe.get_meta")
     def test_get_priority_options_no_field(self, mock_get_meta):
@@ -179,7 +180,7 @@ class TestProjectDashboard(unittest.TestCase):
         mock_meta = mock_get_meta.return_value
         mock_meta.fields = []
         result = get_priority_options()
-        self.assertEqual(result, [])
+        self.assertEqual(result, {"project_priority": [], "company_priority": []})
 
     @patch("project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.frappe.log_error")
     @patch("project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.frappe.get_meta")

--- a/project_enhancements/public/js/dashboard_components/priority_overview.js
+++ b/project_enhancements/public/js/dashboard_components/priority_overview.js
@@ -170,7 +170,8 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
         this.current_view = 'company_priority';
         this.projects = [];
         this.bufferManager = new project_enhancements.dashboard_components.BufferManager(this);
-        this.priorityOptions = [];
+        this.projectPriorityOptions = [];
+        this.companyPriorityOptions = [];
     }
 
     set_view(view) {
@@ -208,8 +209,13 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 
             if (signal.aborted) return;
 
-            if (optionsRes.message && Array.isArray(optionsRes.message)) {
-                this.priorityOptions = optionsRes.message;
+            if (optionsRes.message && !optionsRes.message.error) {
+                this.projectPriorityOptions = optionsRes.message.project_priority || [];
+                this.companyPriorityOptions = optionsRes.message.company_priority || [];
+            } else if (Array.isArray(optionsRes.message)) {
+                // Backward compatibility just in case
+                this.projectPriorityOptions = optionsRes.message;
+                this.companyPriorityOptions = optionsRes.message;
             }
 
             if (projectsRes.message && !projectsRes.message.error) {
@@ -366,7 +372,9 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 
                 // Populate options
                 let optionsHtml = '<option value="">Not Assigned</option>';
-                this.priorityOptions.forEach(opt => {
+                const optionsToUse = field === 'custom_company_priority' ? this.companyPriorityOptions : this.projectPriorityOptions;
+
+                optionsToUse.forEach(opt => {
                     optionsHtml += `<option value="${frappe.utils.escape_html(opt)}">${frappe.utils.escape_html(opt)}</option>`;
                 });
                 select.html(optionsHtml);


### PR DESCRIPTION
Fixes an issue where the Company Priority dropdown in the Project Dashboard was only showing options 1-10 instead of 1-30.

The changes include:
1. Updating `get_priority_options` in `project_dashboard.py` to retrieve options from both `custom_project_priority` and `custom_company_priority` and return them as a dictionary.
2. Updating the corresponding test in `test_project_dashboard.py` to handle the new return signature.
3. Updating `priority_overview.js` to parse the new return signature and use `projectPriorityOptions` and `companyPriorityOptions` dynamically when rendering the `<select>` inputs for each column.

---
*PR created automatically by Jules for task [7701304523133477498](https://jules.google.com/task/7701304523133477498) started by @nbbshaw*