### PR TITLE
feat: implement Master Project doctype and relations

### DIFF
--- a/project_enhancements/fixtures/custom_field.json
+++ b/project_enhancements/fixtures/custom_field.json
@@ -91,5 +91,15 @@
   "label": "Tasks Tree View",
   "insert_after": "custom_tasks_section",
   "name": "Project-custom_tasks_html"
+ },
+ {
+  "doctype": "Custom Field",
+  "dt": "Project",
+  "fieldname": "custom_master_project",
+  "fieldtype": "Link",
+  "label": "Master Project",
+  "options": "Master Project",
+  "insert_after": "project_name",
+  "name": "Project-custom_master_project"
  }
 ]

--- a/project_enhancements/project_enhancements/doctype/master_project/__init__.py
+++ b/project_enhancements/project_enhancements/doctype/master_project/__init__.py
@@ -1,0 +1,4 @@
+import frappe
+
+def execute():
+	pass

--- a/project_enhancements/project_enhancements/doctype/master_project/master_project.js
+++ b/project_enhancements/project_enhancements/doctype/master_project/master_project.js
@@ -1,0 +1,136 @@
+// Copyright (c) 2024, Sapphire Fountains and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Master Project", {
+	refresh: function(frm) {
+		if (frm.doc.__islocal) {
+			frm.get_field("projects_html").$wrapper.html("<p class='text-muted'>Save to view projects.</p>");
+			frm.get_field("tasks_html").$wrapper.html("<p class='text-muted'>Save to view tasks.</p>");
+			return;
+		}
+
+		frm.call({
+			doc: frm.doc,
+			method: "get_projects_and_tasks",
+			callback: function(r) {
+				if (r.message) {
+					render_projects_table(frm, r.message.projects);
+					render_tasks_table(frm, r.message.projects, r.message.tasks);
+				}
+			}
+		});
+	}
+});
+
+function render_projects_table(frm, projects) {
+	let wrapper = frm.get_field("projects_html").$wrapper;
+	if (!projects || projects.length === 0) {
+		wrapper.html("<p class='text-muted'>No projects linked to this Master Project.</p>");
+		return;
+	}
+
+	let html = `
+		<table class="table table-bordered">
+			<thead>
+				<tr>
+					<th>Project</th>
+					<th>Status</th>
+					<th>Priority</th>
+					<th>Progress</th>
+					<th>Due Date</th>
+				</tr>
+			</thead>
+			<tbody>
+	`;
+
+	projects.forEach(p => {
+		let progress = p.percent_complete ? p.percent_complete + "%" : "0%";
+		let due_date = p.expected_end_date ? frappe.datetime.str_to_user(p.expected_end_date) : "";
+		let link = frappe.utils.get_form_link("Project", p.name, true, p.project_name || p.name);
+
+		html += `
+			<tr>
+				<td>${link}</td>
+				<td>${p.status || ""}</td>
+				<td>${p.priority || ""}</td>
+				<td>${progress}</td>
+				<td>${due_date}</td>
+			</tr>
+		`;
+	});
+
+	html += `
+			</tbody>
+		</table>
+	`;
+
+	wrapper.html(html);
+}
+
+function render_tasks_table(frm, projects, tasks) {
+	let wrapper = frm.get_field("tasks_html").$wrapper;
+	if (!projects || projects.length === 0) {
+		wrapper.html("<p class='text-muted'>No tasks to display.</p>");
+		return;
+	}
+
+	// Group tasks by project
+	let tasks_by_project = {};
+	projects.forEach(p => {
+		tasks_by_project[p.name] = [];
+	});
+
+	if (tasks && tasks.length > 0) {
+		tasks.forEach(t => {
+			if (tasks_by_project[t.project]) {
+				tasks_by_project[t.project].push(t);
+			}
+		});
+	}
+
+	let html = `
+		<table class="table table-bordered">
+			<thead>
+				<tr>
+					<th>Task</th>
+					<th>Status</th>
+				</tr>
+			</thead>
+			<tbody>
+	`;
+
+	projects.forEach(p => {
+		let p_link = frappe.utils.get_form_link("Project", p.name, true, p.project_name || p.name);
+		html += `
+			<tr class="table-active">
+				<td colspan="2"><strong>Project: ${p_link}</strong></td>
+			</tr>
+		`;
+
+		let p_tasks = tasks_by_project[p.name] || [];
+		if (p_tasks.length === 0) {
+			html += `
+				<tr>
+					<td colspan="2" class="text-muted">No tasks found for this project.</td>
+				</tr>
+			`;
+		} else {
+			p_tasks.forEach(t => {
+				let t_link = frappe.utils.get_form_link("Task", t.name, true, t.subject || t.name);
+				html += `
+					<tr>
+						<td style="padding-left: 30px;">${t_link}</td>
+						<td>${t.status || ""}</td>
+					</tr>
+				`;
+			});
+		}
+	});
+
+	html += `
+			</tbody>
+		</table>
+	`;
+
+	wrapper.html(html);
+}

--- a/project_enhancements/project_enhancements/doctype/master_project/master_project.json
+++ b/project_enhancements/project_enhancements/doctype/master_project/master_project.json
@@ -1,0 +1,90 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:MP-{YYYY}-{MM}-{####}",
+ "creation": "2024-03-24 10:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "description",
+  "projects_html",
+  "tasks_html"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "projects_html",
+   "fieldtype": "HTML",
+   "label": "Projects"
+  },
+  {
+   "fieldname": "tasks_html",
+   "fieldtype": "HTML",
+   "label": "Tasks"
+  }
+ ],
+ "links": [],
+ "modified": "2024-03-24 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Projects",
+ "name": "Master Project",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1,
+ "search_fields": "title",
+ "title_field": "title",
+ "custom": 0,
+ "is_submittable": 0
+}

--- a/project_enhancements/project_enhancements/doctype/master_project/master_project.py
+++ b/project_enhancements/project_enhancements/doctype/master_project/master_project.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024, Sapphire Fountains and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+class MasterProject(Document):
+	@frappe.whitelist()
+	def get_projects_and_tasks(self):
+		projects = frappe.get_all(
+			"Project",
+			filters={"custom_master_project": self.name},
+			fields=["name", "project_name", "status", "priority", "percent_complete", "expected_end_date"]
+		)
+
+		if not projects:
+			return {"projects": [], "tasks": []}
+
+		project_names = [p["name"] for p in projects]
+
+		tasks = frappe.get_all(
+			"Task",
+			filters={"project": ["in", project_names]},
+			fields=["name", "subject", "status", "project"]
+		)
+
+		return {
+			"projects": projects,
+			"tasks": tasks
+		}

--- a/project_enhancements/project_enhancements/doctype/master_project/test_master_project.py
+++ b/project_enhancements/project_enhancements/doctype/master_project/test_master_project.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2024, Sapphire Fountains and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+class TestMasterProject(FrappeTestCase):
+	pass


### PR DESCRIPTION
I have implemented the "Master Project" functionality per our discussion:

1. **Created Standard `Master Project` DocType:**
   - Lives in the Projects module.
   - Contains fields for `title`, `description`, `projects_html`, and `tasks_html`.
   - Included Python and JavaScript files attached to standard framework triggers.

2. **Added `custom_master_project` Link Field to `Project`:**
   - Modified the `custom_field.json` fixture to ensure the `Project` doctype receives a link field named "Master Project" pointing to the new doctype.

3. **Dynamic HTML Rendering:**
   - On the `Master Project` screen, the backend executes a fast `frappe.get_all` query to find all linked projects and their tasks.
   - The frontend JavaScript injects nicely formatted tables directly into the `projects_html` and `tasks_html` wrappers. The task table is grouped correctly by Project Title, exactly as requested.

---
*PR created automatically by Jules for task [8189320799195451193](https://jules.google.com/task/8189320799195451193) started by @parker-bailey*