### PR TITLE
fix: Correctly assign module to Master Project to fix ModuleNotFoundError

### DIFF
--- a/project_enhancements/project_enhancements/doctype/master_project/master_project.json
+++ b/project_enhancements/project_enhancements/doctype/master_project/master_project.json
@@ -38,7 +38,7 @@
  "links": [],
  "modified": "2024-03-24 10:00:00.000000",
  "modified_by": "Administrator",
- "module": "Projects",
+ "module": "Project Enhancements",
  "name": "Master Project",
  "owner": "Administrator",
  "permissions": [


### PR DESCRIPTION
This fixes an issue where the `Master Project` DocType was incorrectly mapped to the `Projects` module, leading Frappe to look in the `erpnext` app for its controller files during a migration. By setting the `module` attribute to `Project Enhancements`, Frappe correctly path-resolves to the appropriate Python module within the custom app, resolving the `ModuleNotFoundError`.

---
*PR created automatically by Jules for task [13344341641279720928](https://jules.google.com/task/13344341641279720928) started by @parker-bailey*