### PR TITLE
feat: Show Master Project title in link field

### DIFF
--- a/project_enhancements/fixtures/custom_field.json
+++ b/project_enhancements/fixtures/custom_field.json
@@ -100,6 +100,7 @@
   "label": "Master Project",
   "options": "Master Project",
   "insert_after": "project_name",
-  "name": "Project-custom_master_project"
+  "name": "Project-custom_master_project",
+  "show_title_field_in_link": 1
  }
 ]


### PR DESCRIPTION
Update the `custom_master_project` link field on the `Project` DocType to display the title of the linked Master Project instead of its internal ID. This change leverages Frappe's native `show_title_field_in_link` property in the custom field definition, taking advantage of the `title_field` already configured on the `Master Project` DocType.

---
*PR created automatically by Jules for task [3961202809693680460](https://jules.google.com/task/3961202809693680460) started by @parker-bailey*