### PR TITLE
feat: update Master Project ID to match title

### DIFF
--- a/project_enhancements/patches.txt
+++ b/project_enhancements/patches.txt
@@ -6,3 +6,4 @@
 # Patches added in this section will be executed after doctypes are migrated
 project_enhancements.patches.update_project_statuses
 project_enhancements.patches.delete_master_project
+project_enhancements.patches.rename_master_projects

--- a/project_enhancements/patches/rename_master_projects.py
+++ b/project_enhancements/patches/rename_master_projects.py
@@ -1,0 +1,15 @@
+import frappe
+
+def execute():
+	"""Rename existing Master Project records to their title."""
+	master_projects = frappe.get_all(
+		"Master Project",
+		fields=["name", "title"]
+	)
+
+	for mp in master_projects:
+		if mp.name != mp.title:
+			try:
+				frappe.rename_doc("Master Project", mp.name, mp.title, force=True, ignore_permissions=True)
+			except Exception as e:
+				frappe.log_error(f"Failed to rename Master Project {mp.name} to {mp.title}", "Master Project Rename Error")

--- a/project_enhancements/project_enhancements/doctype/master_project/master_project.json
+++ b/project_enhancements/project_enhancements/doctype/master_project/master_project.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:MP-{YYYY}-{MM}-{####}",
+ "autoname": "field:title",
  "creation": "2024-03-24 10:00:00.000000",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -17,7 +17,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Title",
-   "reqd": 1
+   "reqd": 1,
+   "unique": 1
   },
   {
    "fieldname": "description",


### PR DESCRIPTION
This PR updates the Master Project doctype so that its ID correctly uses its title, satisfying a user request.

Key changes:
1. Updates `autoname` to `field:title` and enforces uniqueness on the `title` field in the doctype's JSON schema.
2. Creates and registers a `post_model_sync` patch to safely migrate any existing records using `frappe.rename_doc`.

---
*PR created automatically by Jules for task [12481687885293106130](https://jules.google.com/task/12481687885293106130) started by @parker-bailey*