### PR TITLE
Set Master Project ID to title

### DIFF
--- a/project_enhancements/project_enhancements/doctype/master_project/master_project.json
+++ b/project_enhancements/project_enhancements/doctype/master_project/master_project.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:MP-{YYYY}-{MM}-{####}",
+ "autoname": "field:title",
  "creation": "2024-03-24 10:00:00.000000",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -17,7 +17,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Title",
-   "reqd": 1
+   "reqd": 1,
+   "unique": 1
   },
   {
    "fieldname": "description",

--- a/project_enhancements/project_enhancements/doctype/master_project/test_master_project.py
+++ b/project_enhancements/project_enhancements/doctype/master_project/test_master_project.py
@@ -4,6 +4,39 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-
 class TestMasterProject(FrappeTestCase):
-	pass
+    def test_master_project_naming(self):
+        title = "Test Master Project Naming"
+
+        # Cleanup in case it exists
+        if frappe.db.exists("Master Project", title):
+            frappe.delete_doc("Master Project", title)
+
+        doc = frappe.get_doc({
+            "doctype": "Master Project",
+            "title": title
+        })
+        doc.insert()
+
+        self.assertEqual(doc.name, title)
+
+    def test_master_project_duplicate_title(self):
+        title = "Test Duplicate Master Project Title"
+
+        # Cleanup in case it exists
+        if frappe.db.exists("Master Project", title):
+            frappe.delete_doc("Master Project", title)
+
+        doc1 = frappe.get_doc({
+            "doctype": "Master Project",
+            "title": title
+        })
+        doc1.insert()
+
+        doc2 = frappe.get_doc({
+            "doctype": "Master Project",
+            "title": title
+        })
+
+        with self.assertRaises(frappe.UniqueValidationError):
+            doc2.insert()


### PR DESCRIPTION
Changes the Master Project ID to use its title, ensuring the title is unique.

---
*PR created automatically by Jules for task [4154736761397620149](https://jules.google.com/task/4154736761397620149) started by @parker-bailey*