### PR TITLE
chore(project): add custom_project_description as Data field

### DIFF
--- a/project_enhancements/fixtures/custom_field.json
+++ b/project_enhancements/fixtures/custom_field.json
@@ -102,5 +102,14 @@
   "insert_after": "project_name",
   "name": "Project-custom_master_project",
   "show_title_field_in_link": 1
+ },
+ {
+  "doctype": "Custom Field",
+  "dt": "Project",
+  "fieldname": "custom_project_description",
+  "fieldtype": "Data",
+  "label": "Project Description",
+  "insert_after": "column_break_5",
+  "name": "Project-custom_project_description"
  }
 ]

--- a/project_enhancements/project_enhancements/custom/project.json
+++ b/project_enhancements/project_enhancements/custom/project.json
@@ -63,6 +63,15 @@
    "translatable": 0,
    "unique": 0,
    "width": null
+  },
+  {
+   "doctype": "Custom Field",
+   "dt": "Project",
+   "fieldname": "custom_project_description",
+   "fieldtype": "Data",
+   "label": "Project Description",
+   "insert_after": "column_break_5",
+   "name": "Project-custom_project_description"
   }
  ],
  "custom_perms": [],


### PR DESCRIPTION
Added the `custom_project_description` custom field definition to both `fixtures/custom_field.json` and the exported `custom/project.json` for the Project DocType to formalize the field, set its type to `Data`, and place it in the second column.

---
*PR created automatically by Jules for task [5929323553698535185](https://jules.google.com/task/5929323553698535185) started by @parker-bailey*