### PR TITLE
Fix custom project description fieldtype

### DIFF
--- a/project_enhancements/fixtures/custom_field.json
+++ b/project_enhancements/fixtures/custom_field.json
@@ -107,7 +107,7 @@
   "doctype": "Custom Field",
   "dt": "Project",
   "fieldname": "custom_project_description",
-  "fieldtype": "Data",
+  "fieldtype": "Small Text",
   "label": "Project Description",
   "insert_after": "column_break_5",
   "name": "Project-custom_project_description"

--- a/project_enhancements/project_enhancements/custom/project.json
+++ b/project_enhancements/project_enhancements/custom/project.json
@@ -68,7 +68,7 @@
    "doctype": "Custom Field",
    "dt": "Project",
    "fieldname": "custom_project_description",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "Project Description",
    "insert_after": "column_break_5",
    "name": "Project-custom_project_description"


### PR DESCRIPTION
Change `custom_project_description` fieldtype to `Small Text` to fix migration truncation errors.

---
*PR created automatically by Jules for task [3222957906852355792](https://jules.google.com/task/3222957906852355792) started by @parker-bailey*