### PR TITLE
feat: Wrap long task names in task tree to two lines

### DIFF
--- a/project_enhancements/public/css/task_tree.css
+++ b/project_enhancements/public/css/task_tree.css
@@ -116,3 +116,13 @@
 .hidden-column {
     display: none !important;
 }
+
+.task-name-cell-text {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: normal;
+    word-break: break-word;
+}

--- a/project_enhancements/public/js/task_tree_manager.js
+++ b/project_enhancements/public/js/task_tree_manager.js
@@ -261,12 +261,12 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
                         <div class="task-grid-cell">
                             <div style="padding-left: ${
 								level * 20
-							}px; display: flex; align-items: center; width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+							}px; display: flex; align-items: center; width: 100%;">
                                 <i class="fa fa-bars task-drag-handle mr-2 text-muted" style="cursor: grab; flex-shrink: 0;"></i>
                                 <i class="fa fa-fw ${iconClass} mr-1" style="cursor: pointer; flex-shrink: 0;"></i>
                                 <a href="/app/task/${
 									task.name
-								}" style="overflow: hidden; text-overflow: ellipsis;">${
+								}" class="task-name-cell-text" title="${task.subject}">${
 				task.subject
 			}</a>
                             </div>


### PR DESCRIPTION
This modifies the presentation of task names in the Projects dashboard task tree grid. Previously, long task names were truncated on a single line. They will now wrap to a second line and truncate with an ellipsis if they exceed two lines in length. A `title` attribute has also been added so users can see the full name on hover.

---
*PR created automatically by Jules for task [16496132130573567932](https://jules.google.com/task/16496132130573567932) started by @parker-bailey*