### PR TITLE
Use explicit MM/DD/YY format for task tree dates

### DIFF
--- a/project_enhancements/public/js/task_tree_manager.js
+++ b/project_enhancements/public/js/task_tree_manager.js
@@ -237,10 +237,10 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
 
 		const renderTaskNode = (task, container, level) => {
 			const start_date = task.exp_start_date
-				? frappe.datetime.str_to_user(task.exp_start_date)
+				? frappe.datetime.moment(task.exp_start_date).format("MM/DD/YY")
 				: "Set Date";
 			const end_date = task.exp_end_date
-				? frappe.datetime.str_to_user(task.exp_end_date)
+				? frappe.datetime.moment(task.exp_end_date).format("MM/DD/YY")
 				: "Set Date";
 			const progress = task.progress || 0;
 			const isCollapsed = this.collapsedTasks.has(task.name);
@@ -537,7 +537,7 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
 		$(datepicker.input).on("change", () => {
 			hasChanged = true;
 			const newValue = datepicker.get_value();
-			const displayValue = newValue ? frappe.datetime.str_to_user(newValue) : "Set Date";
+			const displayValue = newValue ? frappe.datetime.moment(newValue).format("MM/DD/YY") : "Set Date";
 
 			link.text(displayValue);
 			cell.addClass("unsaved-change");


### PR DESCRIPTION
Updates `project_enhancements/public/js/task_tree_manager.js` to ensure that task dates strictly display as MM/DD/YY in the custom task tree dashboard components, ignoring user-specific date format settings, to enforce visual consistency as requested.

---
*PR created automatically by Jules for task [13390914804980841148](https://jules.google.com/task/13390914804980841148) started by @parker-bailey*