### PR TITLE
Exclude Group Projects and Internal from Value Stream view

### DIFF
--- a/project_enhancements/public/js/dashboard_components/priority_overview.js
+++ b/project_enhancements/public/js/dashboard_components/priority_overview.js
@@ -305,6 +305,9 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 			let groups = {};
 			projects.forEach((p) => {
 				let stream = p.project_type || "Uncategorized";
+				if (stream === "Group Projects" || stream === "Internal") {
+					return; // Exclude Group Projects and Internal
+				}
 				if (!groups[stream]) {
 					groups[stream] = [];
 				}


### PR DESCRIPTION
This commit updates `priority_overview.js` to skip projects that have `project_type` set to "Group Projects" or "Internal" when generating the Value Stream groupings.

---
*PR created automatically by Jules for task [734856908311926497](https://jules.google.com/task/734856908311926497) started by @nbbshaw*