### PR TITLE
Update project status options

### DIFF
--- a/project_enhancements/fixtures/property_setter.json
+++ b/project_enhancements/fixtures/property_setter.json
@@ -6,7 +6,7 @@
   "doctype_or_field": "DocField",
   "field_name": "status",
   "property": "options",
-  "value": "Active\nOn Hold\nCanceled\nCompleted\nInvoiced",
+  "value": "Active\nClient Hold\nParked\nCompleted\nInvoiced\nPaid\nCanceled",
   "is_system_generated": 0,
   "name": "Project-status-options"
  },

--- a/project_enhancements/project_enhancements/page/project_dashboard/test_project_dashboard.py
+++ b/project_enhancements/project_enhancements/page/project_dashboard/test_project_dashboard.py
@@ -238,10 +238,10 @@ class TestProjectDashboard(unittest.TestCase):
 		"""Test successful retrieval of status options."""
 		mock_meta = mock_get_meta.return_value
 		mock_meta.fields = [
-			frappe._dict({"fieldname": "status", "options": "Active\nOn Hold\nCanceled\nCompleted\nInvoiced"})
+			frappe._dict({"fieldname": "status", "options": "Active\nClient Hold\nParked\nCompleted\nInvoiced\nPaid\nCanceled"})
 		]
 		result = get_status_options()
-		self.assertEqual(result, ["Active", "On Hold", "Canceled", "Completed", "Invoiced"])
+		self.assertEqual(result, ["Active", "Client Hold", "Parked", "Completed", "Invoiced", "Paid", "Canceled"])
 
 	@patch(
 		"project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.frappe.log_error"

--- a/project_enhancements/public/js/dashboard_components/active_internal_projects.js
+++ b/project_enhancements/public/js/dashboard_components/active_internal_projects.js
@@ -82,7 +82,7 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
         `).appendTo(listContainer);
 
 		const tbody = table.find("tbody");
-		const statusOptions = ["Active", "On Hold", "Canceled", "Completed", "Invoiced"];
+		const statusOptions = ["Active", "Client Hold", "Parked", "Completed", "Invoiced", "Paid", "Canceled"];
 		const priorityOptions = ["High", "Medium", "Low"];
 
 		projects.forEach((p) => {
@@ -150,14 +150,20 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
 				return "badge-primary";
 			case "Completed":
 				return "badge-success";
+			case "Paid":
+				return "badge-success";
 			case "Overdue":
 				return "badge-danger";
 			case "Cancelled":
+			case "Canceled":
 				return "badge-danger";
 			case "Working":
 				return "badge-warning";
-			case "On Hold":
+			case "Client Hold":
+			case "Parked":
 				return "badge-warning";
+			case "Invoiced":
+				return "badge-info";
 			default:
 				return "badge-secondary";
 		}

--- a/project_enhancements/public/js/dashboard_components/completed_projects.js
+++ b/project_enhancements/public/js/dashboard_components/completed_projects.js
@@ -136,14 +136,20 @@ project_enhancements.dashboard_components.CompletedProjects = class CompletedPro
 				return "badge-primary";
 			case "Completed":
 				return "badge-success";
+			case "Paid":
+				return "badge-success";
 			case "Overdue":
 				return "badge-danger";
 			case "Cancelled":
+			case "Canceled":
 				return "badge-danger";
 			case "Working":
 				return "badge-warning";
-			case "On Hold":
+			case "Client Hold":
+			case "Parked":
 				return "badge-warning";
+			case "Invoiced":
+				return "badge-info";
 			default:
 				return "badge-secondary";
 		}

--- a/project_enhancements/public/js/dashboard_components/priority_overview.js
+++ b/project_enhancements/public/js/dashboard_components/priority_overview.js
@@ -555,14 +555,20 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 				return "badge-primary";
 			case "Completed":
 				return "badge-success";
+			case "Paid":
+				return "badge-success";
 			case "Overdue":
 				return "badge-danger";
 			case "Cancelled":
+			case "Canceled":
 				return "badge-danger";
 			case "Working":
 				return "badge-warning";
-			case "On Hold":
+			case "Client Hold":
+			case "Parked":
 				return "badge-warning";
+			case "Invoiced":
+				return "badge-info";
 			default:
 				return "badge-secondary";
 		}

--- a/project_enhancements/public/js/task_tree_manager.js
+++ b/project_enhancements/public/js/task_tree_manager.js
@@ -361,6 +361,9 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
 			case "Completed":
 				color = "#28a745";
 				break;
+			case "Paid":
+				color = "#28a745";
+				break;
 			case "Overdue":
 				color = "#dc3545";
 				break;


### PR DESCRIPTION
Updates project status field options and associated frontend badge mapping based on user requirements. Options changed to `Active`, `Client Hold`, `Parked`, `Completed`, `Invoiced`, `Paid`, `Canceled`.

---
*PR created automatically by Jules for task [10002775680304589768](https://jules.google.com/task/10002775680304589768) started by @nbbshaw*