### PR TITLE
fix: lazy load Task Tree when tab becomes visible

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -78,15 +78,17 @@ frappe.ui.form.on("Project", {
 					}
 				};
 
-				// Override render to ensure Frappe's tab lazy rendering doesn't clear our DOM
-				// By re-instantiating on render, it loads automatically just like gantt (or any other field)
-				// when its parent wrapper is available or brought into view.
-				wrapperField.render = function() {
+				// Override refresh to ensure Frappe's tab lazy rendering doesn't clear our DOM.
+				// Frappe calls refresh() when the tab is made visible.
+				// By re-instantiating on refresh, it loads automatically when the tab is clicked,
+				// avoiding hidden 0x0 dimension errors.
+				const original_refresh = wrapperField.refresh;
+				wrapperField.refresh = function() {
+					if (original_refresh) {
+						original_refresh.call(this);
+					}
 					renderTaskTree.call(this);
 				};
-
-				// Eagerly try to render right away
-				renderTaskTree.call(wrapperField);
 			}
 		}
 


### PR DESCRIPTION
This fix ensures the custom Task Tree within Frappe projects correctly handles lazy-loading. Previously, overriding `.render` and eagerly attempting to draw the component while the tab was hidden caused UI bugs and layout failure (0x0 dimensions). Changing the override to `.refresh` correctly delegates to Frappe's tab lifecycle, properly wiping the DOM and re-injecting the component when the tab becomes active.

---
*PR created automatically by Jules for task [18042819135972160831](https://jules.google.com/task/18042819135972160831) started by @nbbshaw*