### PR TITLE
Fix Task Tree View rendering in Project form

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -88,12 +88,17 @@ frappe.ui.form.on("Project", {
 					}
 				};
 
-				// Override render to ensure Frappe's tab lazy rendering doesn't clear our DOM
-				// By re-instantiating on render, it loads automatically just like gantt (or any other field)
+				// Override refresh to ensure Frappe's tab lazy rendering doesn't clear our DOM
+				// By re-instantiating on refresh, it loads automatically just like gantt (or any other field)
 				// when its parent wrapper is available or brought into view.
-				wrapperField.render = function () {
+				const original_refresh = wrapperField.refresh;
+				wrapperField.refresh = function () {
+					if (original_refresh) {
+						original_refresh.call(this);
+					}
 					renderTaskTree.call(this);
 				};
+				wrapperField.refresh();
 			}
 		}
 


### PR DESCRIPTION
Fixes the missing execution trigger preventing the Task Tree from rendering inside the custom HTML field. Frappe's field lifecycle calls `.refresh()`, not `.render()`, and the override is now properly invoked upon creation to ensure immediate DOM injection.

---
*PR created automatically by Jules for task [8197703664837456400](https://jules.google.com/task/8197703664837456400) started by @nbbshaw*