### PR TITLE
Fix Frappe lazy-loading custom HTML field rendering bug

### DIFF
--- a/project_enhancements/project_enhancements/doctype/project/project.js
+++ b/project_enhancements/project_enhancements/doctype/project/project.js
@@ -27,110 +27,132 @@ frappe.ui.form.on("Project", {
 			});
 		}
 
-		const gantt_wrapper = frm.get_field("custom_gantt_chart_html").$wrapper;
-		gantt_wrapper.css({
-			height: "500px",
-			overflow: "hidden",
-		});
+		const wrapperField = frm.get_field("custom_gantt_chart_html");
 
-		gantt_wrapper
-			.empty()
-			.html('<div class="gantt-chart-container" style="height: 100%;"></div>');
+		if (wrapperField) {
+			if (!wrapperField.__custom_gantt_bound) {
+				const original_refresh = wrapperField.refresh;
 
-		load_cdn_assets()
-			.then(() => {
-				const chart_container = gantt_wrapper.find(".gantt-chart-container");
-				chart_container.html('<p class="text-muted">Loading chart data...</p>');
+				wrapperField.refresh = function () {
+					if (original_refresh) {
+						original_refresh.call(this);
+					}
 
-				frappe.call({
-					method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.get_gantt_tasks_for_project",
-					args: { project_name: frm.doc.name },
-					callback: function (r) {
-						if (r.message && !r.message.error && r.message.length > 0) {
-							const tasks = r.message;
+					if (this.$wrapper && this.$wrapper.children().length === 0) {
+						const gantt_wrapper = this.$wrapper;
+						gantt_wrapper.css({
+							height: "500px",
+							overflow: "hidden",
+						});
 
-							const options = {
-								view_mode: "Day",
-								scroll_to: "today",
-								on_click: (task) => frappe.set_route("Form", "Task", task.id),
-								on_date_change: (task, start, end) => {
-									frappe.call({
-										method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.update_task_dates_from_gantt",
-										args: {
-											task_name: task.id,
-											start_date: moment(start).format("YYYY-MM-DD"),
-											end_date: moment(end).format("YYYY-MM-DD"),
-										},
-									});
-								},
-								on_progress_change: (task, progress) => {
-									frappe.call({
-										method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.update_task_progress_from_gantt",
-										args: {
-											task_name: task.id,
-											progress: parseInt(progress),
-										},
-									});
-								},
-							};
+						gantt_wrapper
+							.empty()
+							.html('<div class="gantt-chart-container" style="height: 100%;"></div>');
 
-							// It is now safe to instantiate the Gantt chart
-							gantt_wrapper.find(".gantt-chart-container").empty();
-							const gantt = new Gantt(
-								gantt_wrapper.find(".gantt-chart-container")[0],
-								tasks,
-								options
-							);
+						load_cdn_assets()
+							.then(() => {
+								const chart_container = gantt_wrapper.find(".gantt-chart-container");
+								chart_container.html('<p class="text-muted">Loading chart data...</p>');
 
-							const gantt_container = gantt_wrapper.find(".gantt-container");
-							gantt_container.css({
-								"overflow-x": "scroll",
-								"overflow-y": "auto",
-								"max-height": "100%",
+								frappe.call({
+									method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.get_gantt_tasks_for_project",
+									args: { project_name: frm.doc.name },
+									callback: function (r) {
+										if (r.message && !r.message.error && r.message.length > 0) {
+											const tasks = r.message;
+
+											const options = {
+												view_mode: "Day",
+												scroll_to: "today",
+												on_click: (task) => frappe.set_route("Form", "Task", task.id),
+												on_date_change: (task, start, end) => {
+													frappe.call({
+														method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.update_task_dates_from_gantt",
+														args: {
+															task_name: task.id,
+															start_date: moment(start).format("YYYY-MM-DD"),
+															end_date: moment(end).format("YYYY-MM-DD"),
+														},
+													});
+												},
+												on_progress_change: (task, progress) => {
+													frappe.call({
+														method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.update_task_progress_from_gantt",
+														args: {
+															task_name: task.id,
+															progress: parseInt(progress),
+														},
+													});
+												},
+											};
+
+											// It is now safe to instantiate the Gantt chart
+											gantt_wrapper.find(".gantt-chart-container").empty();
+											const gantt = new Gantt(
+												gantt_wrapper.find(".gantt-chart-container")[0],
+												tasks,
+												options
+											);
+
+											const gantt_container = gantt_wrapper.find(".gantt-container");
+											gantt_container.css({
+												"overflow-x": "scroll",
+												"overflow-y": "auto",
+												"max-height": "100%",
+											});
+
+											// Adjust scroll to align "Today" to the left
+											setTimeout(() => {
+												// Calculate dynamic class for today, e.g., .date_2023-10-27
+												const today_date_class = ".date_" + moment().format("YYYY-MM-DD");
+												let today_highlight = gantt_wrapper.find(today_date_class);
+
+												if (today_highlight.length === 0) {
+													today_highlight = gantt_wrapper.find(
+														".current-date-highlight"
+													);
+												}
+
+												if (today_highlight.length > 0) {
+													// If the element exists, scroll to it directly
+													// position().left is relative to the scrollable container content
+													const scroll_pos = today_highlight.position().left;
+													gantt_container.scrollLeft(scroll_pos - 20); // 20px padding
+												} else {
+													// Fallback: assumes scroll_to: 'today' centered the view
+													const gantt_width = gantt_container.width();
+													const current_scroll = gantt_container.scrollLeft();
+													gantt_container.scrollLeft(
+														current_scroll + gantt_width / 2 - 50
+													);
+												}
+											}, 1000);
+										} else {
+											gantt_wrapper.html(
+												'<p class="text-muted">No tasks found for this project.</p>'
+											);
+										}
+									},
+								});
+							})
+							.catch((error) => {
+								console.error("Failed to load Gantt chart from CDN:", error);
+								gantt_wrapper
+									.empty()
+									.html(
+										'<p class="text-danger">Error: Could not load Gantt chart library from CDN. Check browser console for details.</p>'
+									);
 							});
+					}
+				};
 
-							// Adjust scroll to align "Today" to the left
-							setTimeout(() => {
-								// Calculate dynamic class for today, e.g., .date_2023-10-27
-								const today_date_class = ".date_" + moment().format("YYYY-MM-DD");
-								let today_highlight = gantt_wrapper.find(today_date_class);
+				wrapperField.__custom_gantt_bound = true;
+			}
 
-								if (today_highlight.length === 0) {
-									today_highlight = gantt_wrapper.find(
-										".current-date-highlight"
-									);
-								}
-
-								if (today_highlight.length > 0) {
-									// If the element exists, scroll to it directly
-									// position().left is relative to the scrollable container content
-									const scroll_pos = today_highlight.position().left;
-									gantt_container.scrollLeft(scroll_pos - 20); // 20px padding
-								} else {
-									// Fallback: assumes scroll_to: 'today' centered the view
-									const gantt_width = gantt_container.width();
-									const current_scroll = gantt_container.scrollLeft();
-									gantt_container.scrollLeft(
-										current_scroll + gantt_width / 2 - 50
-									);
-								}
-							}, 1000);
-						} else {
-							gantt_wrapper.html(
-								'<p class="text-muted">No tasks found for this project.</p>'
-							);
-						}
-					},
-				});
-			})
-			.catch((error) => {
-				console.error("Failed to load Gantt chart from CDN:", error);
-				gantt_wrapper
-					.empty()
-					.html(
-						'<p class="text-danger">Error: Could not load Gantt chart library from CDN. Check browser console for details.</p>'
-					);
-			});
+			if (wrapperField.$wrapper) {
+				wrapperField.refresh();
+			}
+		}
 	},
 });
 

--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -51,54 +51,60 @@ frappe.ui.form.on("Project", {
 		if (frappe.has_permission("Task", "read")) {
 			const wrapperField = frm.get_field("custom_tasks_html");
 
-			if (wrapperField && wrapperField.$wrapper) {
-				const renderTaskTree = function () {
-					if (this.$wrapper && this.$wrapper.children().length === 0) {
-						const docName = frm.doc.name;
+			if (wrapperField) {
+				// Only bind the override once to avoid memory leaks on multiple saves
+				if (!wrapperField.__custom_tree_bound) {
+					const original_refresh = wrapperField.refresh;
 
-						frappe
-							.require("/assets/project_enhancements/js/task_tree_manager.js")
-							.then(() => {
-								if (
-									window.project_enhancements &&
-									project_enhancements.TaskTreeManager
-								) {
-									console.log(`Rendering Task Tree for Project: ${docName}`);
+					wrapperField.refresh = function () {
+						// Let Frappe do its native HTML field setup first
+						if (original_refresh) {
+							original_refresh.call(this);
+						}
 
-									if (frm.task_tree_instance) {
-										if (frm.task_tree_instance.sortableInstances) {
-											frm.task_tree_instance.sortableInstances.forEach(
-												(instance) => instance.destroy()
-											);
+						// By the time this runs, the tab has been clicked and this.$wrapper is guaranteed to exist
+						if (this.$wrapper && this.$wrapper.children().length === 0) {
+							const docName = frm.doc.name;
+
+							frappe
+								.require("/assets/project_enhancements/js/task_tree_manager.js")
+								.then(() => {
+									if (
+										window.project_enhancements &&
+										project_enhancements.TaskTreeManager
+									) {
+										console.log(`Rendering Task Tree for Project: ${docName}`);
+
+										if (frm.task_tree_instance) {
+											if (frm.task_tree_instance.sortableInstances) {
+												frm.task_tree_instance.sortableInstances.forEach(
+													(instance) => instance.destroy()
+												);
+											}
+											frm.task_tree_instance = null;
 										}
-										frm.task_tree_instance = null;
+
+										this.$wrapper
+											.empty()
+											.html('<div class="task-tree-container"></div>');
+
+										frm.task_tree_instance =
+											new project_enhancements.TaskTreeManager({
+												wrapper: this.$wrapper.find(".task-tree-container"),
+												projectName: docName,
+											});
 									}
+								});
+						}
+					};
 
-									this.$wrapper
-										.empty()
-										.html('<div class="task-tree-container"></div>');
+					wrapperField.__custom_tree_bound = true;
+				}
 
-									frm.task_tree_instance =
-										new project_enhancements.TaskTreeManager({
-											wrapper: this.$wrapper.find(".task-tree-container"),
-											projectName: docName,
-										});
-								}
-							});
-					}
-				};
-
-				// Override refresh to ensure Frappe's tab lazy rendering doesn't clear our DOM
-				// By re-instantiating on refresh, it loads automatically just like gantt (or any other field)
-				// when its parent wrapper is available or brought into view.
-				const original_refresh = wrapperField.refresh;
-				wrapperField.refresh = function () {
-					if (original_refresh) {
-						original_refresh.call(this);
-					}
-					renderTaskTree.call(this);
-				};
-				wrapperField.refresh();
+				// If the wrapper is already active (e.g., page was refreshed while already on the tab)
+				if (wrapperField.$wrapper) {
+					wrapperField.refresh();
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes the issue where custom HTML fields inside lazily-loaded Frappe tabs failed to render due to their missing `$wrapper` element on initial form load.

---
*PR created automatically by Jules for task [4957619526740675141](https://jules.google.com/task/4957619526740675141) started by @nbbshaw*