### PR TITLE
feat: Auto-load Tasks Tree View on Scope tab click

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -133,6 +133,22 @@ frappe.ui.form.on("Project", {
 		$(window).on("hashchange", checkAndSwitchToScopeTab);
 
 		// =========================================================================
+		// 4.5. AUTO-LOAD TREE VIEW ON NATIVE TAB CLICK
+		// =========================================================================
+		frm.$wrapper.find('.form-tabs').on('click', '.nav-item[data-fieldname="custom_scope"], .nav-item[data-label="Scope"]', function () {
+			// A slight timeout ensures Frappe has finished rendering the tab pane's DOM visibility
+			setTimeout(() => {
+				const wrapperField = frm.get_field("custom_tasks_html");
+
+				// Only force the refresh if the wrapper exists and hasn't been populated yet
+				if (wrapperField && wrapperField.$wrapper && wrapperField.$wrapper.children().length === 0) {
+					console.log("Scope tab opened natively - triggering Tree View render.");
+					wrapperField.refresh();
+				}
+			}, 150);
+		});
+
+		// =========================================================================
 		// 5. HIDE STANDARD VIEW BUTTON
 		// =========================================================================
 		const styleId = "hide-standard-view-btn-style";


### PR DESCRIPTION
This PR introduces a small UX improvement for the Project Form's Tasks Tree View. Previously, the tree view might not load correctly or automatically when switching to the "Scope" tab manually. We added an event listener attached to the tab's click event. It introduces a slight timeout to wait for Frappe to change the tab's display property to block, then checks if the custom wrapper hasn't been populated yet, and if so, explicitly triggers the field's `refresh()` method to render the view. This improves consistency and ensures users see the task tree instantly without extra interactions.

---
*PR created automatically by Jules for task [2174063470350190960](https://jules.google.com/task/2174063470350190960) started by @nbbshaw*