### PR TITLE
feat(tasks): implement delete task functionality in tree view

### DIFF
--- a/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.py
+++ b/project_enhancements/project_enhancements/page/project_dashboard/project_dashboard.py
@@ -1094,3 +1094,26 @@ def update_multiple_docs(project_updates, task_updates):
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), "Error in batch update")
 		return {"status": "error", "message": str(e)}
+
+@frappe.whitelist()
+def delete_task(task_name):
+	"""Deletes a single task.
+
+	Args:
+	    task_name (str): The name (ID) of the task to delete.
+
+	Returns:
+	    dict: A dictionary indicating the status of the operation.
+	"""
+	if not task_name:
+		return {"status": "error", "message": "Task name is required."}
+
+	try:
+		if not frappe.has_permission("Task", ptype="delete", doc=task_name):
+			return {"status": "error", "message": "You do not have permission to delete this task."}
+
+		frappe.delete_doc("Task", task_name)
+		return {"status": "success"}
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), f"Error deleting task {task_name}")
+		return {"status": "error", "message": "Could not delete task. Please check the logs."}

--- a/project_enhancements/public/css/task_tree.css
+++ b/project_enhancements/public/css/task_tree.css
@@ -87,6 +87,13 @@
 	min-width: 0;
 }
 
+.task-grid-header > .task-grid-cell.actions-cell,
+.task-grid-row > .task-grid-cell.actions-cell {
+	flex: 0.5; /* Actions */
+	min-width: 0;
+	justify-content: center;
+}
+
 .task-grid-cell select.form-control {
 	width: 100%;
 }

--- a/project_enhancements/public/js/task_tree_manager.js
+++ b/project_enhancements/public/js/task_tree_manager.js
@@ -197,6 +197,7 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
                         <div class="task-grid-cell ${
 							this.columnVisibility.duration ? "" : "hidden-column"
 						}" data-column="duration">Duration (hrs)</div>
+                        ${!this.readonly ? `<div class="task-grid-cell actions-cell" data-column="actions">Actions</div>` : ''}
                     </div>
                     <div class="task-grid-body"></div>
                 </div>
@@ -372,6 +373,9 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
 			}" data-field="expected_time" data-task-id="${task.name}" data-original-value="${
 				task.expected_time || 0
 			}" data-column="duration"><a href="#">${task.expected_time || 0}</a></div>
+                        ${!this.readonly ? `<div class="task-grid-cell actions-cell" data-column="actions">
+                            <button class="btn btn-xs btn-danger delete-task-btn" title="Delete Task" data-task-name="${task.name}" data-task-subject="${task.subject}"><i class="fa fa-trash"></i></button>
+                        </div>` : ''}
                     </div>
                     <div class="child-tasks-container" style="${
 						isCollapsed ? "display: none;" : ""
@@ -571,6 +575,58 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
 			e.preventDefault();
 			if (me.readonly) return;
 			me.showAssigneeDialog($(this));
+		});
+
+		// Delete Task
+		this.wrapper.on("click", ".delete-task-btn", function (e) {
+			e.stopPropagation();
+			const btn = $(this);
+			const taskName = btn.data("task-name");
+			const taskSubject = btn.data("task-subject");
+
+			frappe.confirm(
+				`Are you sure you want to delete task ${taskSubject}? This action cannot be undone.`,
+				() => {
+					frappe.call({
+						method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.delete_task",
+						args: { task_name: taskName },
+						callback: (r) => {
+							if (r.message && r.message.status === "success") {
+								frappe.show_alert({ message: "Task deleted successfully.", indicator: "green" });
+
+								// Remove from local array
+								const removeTask = (tasksList, idToRemove) => {
+									for (let i = 0; i < tasksList.length; i++) {
+										if (tasksList[i].name === idToRemove) {
+											tasksList.splice(i, 1);
+											return true;
+										}
+										if (tasksList[i].children && tasksList[i].children.length > 0) {
+											if (removeTask(tasksList[i].children, idToRemove)) {
+												return true;
+											}
+										}
+									}
+									return false;
+								};
+
+
+								removeTask(me.tasks, taskName);
+
+								// Clean up any pending changes
+								if (me.pendingChanges && me.pendingChanges[taskName]) {
+									delete me.pendingChanges[taskName];
+								}
+
+								// Re-render
+								me.applyFilters();
+							} else {
+								frappe.show_alert({ message: r.message.message || "Failed to delete task.", indicator: "red" });
+							}
+						}
+					});
+				}
+			);
 		});
 
 		// Column Toggle


### PR DESCRIPTION
Adds a "Delete Task" feature to the TaskTreeManager component. Tasks can now be deleted directly from the tree view via a new "Actions" column. The backend securely checks for delete permissions and properly handles the deletion using `frappe.delete_doc`. The frontend removes the task from the local state array without reloading the page.

---
*PR created automatically by Jules for task [1889111332809267641](https://jules.google.com/task/1889111332809267641) started by @nbbshaw*