### PR TITLE
Auto-load Tasks Tree View on Project page load

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -101,10 +101,60 @@ frappe.ui.form.on("Project", {
 					wrapperField.__custom_tree_bound = true;
 				}
 
-				// If the wrapper is already active (e.g., page was refreshed while already on the tab)
-				if (wrapperField.$wrapper) {
-					wrapperField.refresh();
-				}
+				// Eagerly render on page load. The field's $wrapper may not be built
+				// yet at the moment this refresh handler runs, so poll for it instead of
+				// giving up after a single check. This renders the tree automatically
+				// without waiting for the user to click the Scope tab. The tree is pure
+				// DOM (no size dependency), so it renders fine while its tab is hidden.
+				const pollProject = frm.doc.name;
+				let treeRenderAttempts = 0;
+				let scopeTabBuildForced = false;
+
+				// Fallback for Frappe builds that lazily render a tab's fields only when
+				// the tab is first shown: briefly activate the Scope tab to force its
+				// content to build, then restore the originally active tab. The
+				// shown.bs.tab handler (section 4.5) then renders the tree.
+				const forceScopeTabBuild = () => {
+					const $scopeLink = frm.$wrapper
+						.find(
+							'.form-tabs .nav-item[data-label="Scope"] a.nav-link, ' +
+								'.form-tabs .nav-item[data-fieldname="custom_scope"] a.nav-link'
+						)
+						.first();
+					const $activeLink = frm.$wrapper.find(".form-tabs .nav-link.active").first();
+					if (!$scopeLink.length || !$scopeLink.tab) {
+						return;
+					}
+					// Already on the Scope tab: just show it (no restore needed).
+					if (!$activeLink.length || $activeLink[0] === $scopeLink[0]) {
+						$scopeLink.tab("show");
+						return;
+					}
+					// Restore the user's tab once Scope has finished building/showing.
+					$scopeLink.one("shown.bs.tab", () => $activeLink.tab("show"));
+					$scopeLink.tab("show");
+				};
+
+				const tryRenderTaskTree = () => {
+					// Abort if the form navigated to a different project (SPA navigation)
+					if (frm.doc.name !== pollProject) {
+						return;
+					}
+					if (wrapperField.$wrapper) {
+						wrapperField.refresh();
+						return;
+					}
+					// Wrapper still not built after a short grace period: force the
+					// Scope tab to build its content (handles lazy tab rendering).
+					if (treeRenderAttempts === 15 && !scopeTabBuildForced) {
+						scopeTabBuildForced = true;
+						forceScopeTabBuild();
+					}
+					if (treeRenderAttempts++ < 60) {
+						setTimeout(tryRenderTaskTree, 100);
+					}
+				};
+				tryRenderTaskTree();
 			}
 		}
 


### PR DESCRIPTION
## What changed

The Tasks Tree View (`custom_tasks_html` HTML field on the Project DocType, in the "Tasks Tree" section of the Scope tab) now renders automatically on page load instead of staying blank until the user clicks the Scope tab.

## Why

The tree was only rendered by the `shown.bs.tab` handler (Scope tab click) and by a single one-shot `if (wrapperField.$wrapper) wrapperField.refresh()` check on form `refresh`. On a fresh page load the HTML field's `$wrapper` isn't built yet at the instant the refresh handler runs, so that one-shot check failed and bailed — leaving the tree empty until a manual tab click.

## How

In `project_enhancements/public/js/project_form_script.js`, the one-shot check is replaced with a bounded poll that:

- Waits for the field's `$wrapper` to be built, then renders the tree immediately — no tab click required. The tree is pure DOM with no size dependency, so it renders fine while the Scope tab is hidden (no flicker).
- Aborts if the form navigates to a different project (SPA navigation), so stale polls don't render into the wrong form.
- Falls back, only if the wrapper never appears within ~1.5s, to briefly activating the Scope tab to force its content to build (for Frappe builds that lazily render tab fields on first show), then restores the originally active tab. The existing `shown.bs.tab` handler then renders the tree.
- Relies on the existing render-override guard (`children().length === 0`) so the poll and the tab handler can't double-render.

The Gantt chart is intentionally left unchanged — it needs the tab visible to size itself, so eager off-screen rendering would break it.

## Reviewer notes

The Frappe framework isn't installed in this worktree, so I couldn't confirm whether this Frappe version builds tab field wrappers up-front or lazily. The fallback covers both. If tab fields render up-front (most likely), the tree loads instantly with no visual change. If they render lazily, there may be a brief one-time flash to the Scope tab and back on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
