### PR TITLE
Add Project ID column, selectable columns, and Spend % to dashboards

### DIFF
--- a/Custom HTML Block/projects_dashboard.js
+++ b/Custom HTML Block/projects_dashboard.js
@@ -24,6 +24,44 @@
         'completed-projects': { col: 'project_name', order: 'asc' }
     };
 
+    const ColumnSelector = project_enhancements.dashboard_components.ColumnSelector;
+    const column_selectors = {
+        'priority-overview': new ColumnSelector('chb_priority_overview_columns', [
+            { key: 'project_name', label: 'Project Name', locked: true },
+            { key: 'project_id', label: 'Project ID' },
+            { key: 'company_priority', label: 'Company Priority' },
+            { key: 'project_priority', label: 'Project Priority' },
+            { key: 'percent_complete', label: 'Completion' },
+            { key: 'spend_percent', label: 'Spend %' }
+        ]),
+        'active-internal-projects': new ColumnSelector('chb_active_internal_columns', [
+            { key: 'project_name', label: 'Project Name', locked: true },
+            { key: 'project_id', label: 'Project ID' },
+            { key: 'status', label: 'Status' },
+            { key: 'custom_project_priority', label: 'Priority' },
+            { key: 'percent_complete', label: '% Complete' },
+            { key: 'project_user', label: 'Assigned To' }
+        ]),
+        'completed-projects': new ColumnSelector('chb_completed_columns', [
+            { key: 'project_name', label: 'Project Name', locked: true },
+            { key: 'project_id', label: 'Project ID' },
+            { key: 'status', label: 'Status' },
+            { key: 'project_type', label: 'Type' },
+            { key: 'project_user', label: 'Assigned To' }
+        ])
+    };
+
+    function render_column_toolbar(container) {
+        let selector = column_selectors[current_tab];
+        if (!selector) return;
+        let toolbar = $('<div class="dashboard-list-toolbar"></div>');
+        container.append(toolbar);
+        selector.render_button(toolbar, () => selector.apply(container));
+    }
+
+    // Project ID header is non-sortable; built inline to sit beside Project Name.
+    const project_id_th = '<th class="dashcol dashcol-project_id" style="min-width: 120px; white-space: nowrap;">Project ID</th>';
+
     const api_call = (method, args = {}) => {
         return new Promise((resolve, reject) => {
             frappe.call({
@@ -548,12 +586,12 @@
         return `<span class="badge badge-secondary">${frappe.utils.escape_html(p)}</span>`;
     }
 
-    function build_editable_priority_cell(project_name, field, current_val, options_array) {
-        let opts_html = '<option value="">Not Assigned</option>' + 
+    function build_editable_priority_cell(project_name, field, current_val, options_array, col_key) {
+        let opts_html = '<option value="">Not Assigned</option>' +
             options_array.map(opt => `<option value="${opt}" ${opt === current_val ? 'selected' : ''}>${opt}</option>`).join('');
-        
+
         return `
-            <td class="editable-priority" data-project="${project_name}" data-field="${field}" style="min-width: 140px;">
+            <td class="editable-priority dashcol dashcol-${col_key}" data-project="${project_name}" data-field="${field}" style="min-width: 140px;">
                 <div class="static-view" style="cursor: pointer;" title="Click to edit">
                     ${get_priority_badge(current_val)}
                 </div>
@@ -585,7 +623,7 @@
 
     function th(col_name, label, title="") {
         let state = sort_state[current_tab];
-        let cls = "sortable-header";
+        let cls = "sortable-header dashcol dashcol-" + col_name;
         if (state && state.col === col_name) {
             cls += " active-sort sort-" + state.order;
         }
@@ -618,10 +656,11 @@
                 <thead class="thead-light">
                     <tr>
                         ${th('project_name', 'Project Name')}
+                        ${project_id_th}
                         ${th('company_priority', 'Company Priority')}
                         ${th('project_priority', 'Project Priority', 'Groups by Value Stream')}
                         ${th('percent_complete', 'Completion')}
-                        ${th('budget_health', 'Budget Health')}
+                        ${th('spend_percent', 'Spend %', 'Spend as % of total project budget')}
                     </tr>
                 </thead>
                 <tbody></tbody>
@@ -629,15 +668,18 @@
         `);
 
         projects.forEach(p => {
-            let budget_health = (parseFloat(p.custom_project_dollar_amount) || 0) - (parseFloat(p.estimated_costing) || 0);
-            let budget_color = budget_health >= 0 ? "text-success" : "text-danger";
-            
+            let total_budget = parseFloat(p.custom_project_dollar_amount) || 0;
+            let spend = parseFloat(p.estimated_costing) || 0;
+            let spend_percent = total_budget ? (spend / total_budget) * 100 : 0;
+            let spend_color = spend_percent > 100 ? "text-danger" : "text-success";
+
             let row = $(`
                 <tr>
-                    <td style="min-width: 200px;"><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
-                    ${build_editable_priority_cell(p.name, 'custom_company_priority', p.custom_company_priority, priority_options.company_priority || [])}
-                    ${build_editable_priority_cell(p.name, 'custom_project_priority', p.custom_project_priority, priority_options.project_priority || [])}
-                    <td style="min-width: 150px;">
+                    <td class="dashcol dashcol-project_name project-name-cell" style="min-width: 200px;"><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
+                    <td class="dashcol dashcol-project_id project-id-cell"><a href="/app/project/${p.name}" class="text-muted">${p.name}</a></td>
+                    ${build_editable_priority_cell(p.name, 'custom_company_priority', p.custom_company_priority, priority_options.company_priority || [], 'company_priority')}
+                    ${build_editable_priority_cell(p.name, 'custom_project_priority', p.custom_project_priority, priority_options.project_priority || [], 'project_priority')}
+                    <td class="dashcol dashcol-percent_complete" style="min-width: 150px;">
                         <div class="d-flex align-items-center">
                             <div class="progress flex-grow-1 mr-2" style="height: 10px;">
                                 <div class="progress-bar bg-primary" style="width: ${p.percent_complete || 0}%"></div>
@@ -645,7 +687,7 @@
                             <span class="small font-weight-bold">${Math.round(p.percent_complete || 0)}%</span>
                         </div>
                     </td>
-                    <td class="font-weight-bold ${budget_color}" style="min-width: 140px;">${frappe.format(budget_health, {fieldtype: "Currency"})}</td>
+                    <td class="dashcol dashcol-spend_percent font-weight-bold ${spend_color}" style="min-width: 140px;">${total_budget ? Math.round(spend_percent) + '%' : '—'}</td>
                 </tr>
             `);
             table.find('tbody').append(row);
@@ -688,6 +730,7 @@
     function render_priority_overview() {
         let container = $root.find('#dashboard-content');
         container.empty();
+        render_column_toolbar(container);
 
         let state = sort_state['priority-overview'];
         let active_projects = project_data.filter(p => p.is_active === "Yes");
@@ -726,10 +769,12 @@
                     diff = get_priority_weight(a.custom_company_priority) - get_priority_weight(b.custom_company_priority);
                 } else if (state.col === 'percent_complete') {
                     diff = (parseFloat(a.percent_complete) || 0) - (parseFloat(b.percent_complete) || 0);
-                } else if (state.col === 'budget_health') {
-                    let healthA = (parseFloat(a.custom_project_dollar_amount) || 0) - (parseFloat(a.estimated_costing) || 0);
-                    let healthB = (parseFloat(b.custom_project_dollar_amount) || 0) - (parseFloat(b.estimated_costing) || 0);
-                    diff = healthA - healthB;
+                } else if (state.col === 'spend_percent') {
+                    let budgetA = parseFloat(a.custom_project_dollar_amount) || 0;
+                    let budgetB = parseFloat(b.custom_project_dollar_amount) || 0;
+                    let pctA = budgetA ? ((parseFloat(a.estimated_costing) || 0) / budgetA) * 100 : 0;
+                    let pctB = budgetB ? ((parseFloat(b.estimated_costing) || 0) / budgetB) * 100 : 0;
+                    diff = pctA - pctB;
                 }
                 
                 if (diff === 0 && state.col !== 'project_name') {
@@ -739,6 +784,8 @@
             });
             container.append(build_priority_table(projects_to_show));
         }
+
+        column_selectors['priority-overview'].apply(container);
     }
 
     function build_internal_table(projects) {
@@ -748,6 +795,7 @@
                 <thead class="thead-light">
                     <tr>
                         ${th('project_name', 'Project Name')}
+                        ${project_id_th}
                         ${th('status', 'Status')}
                         ${th('custom_project_priority', 'Priority')}
                         ${th('percent_complete', '% Complete')}
@@ -771,10 +819,11 @@
 
             table.find('tbody').append(`
                 <tr>
-                    <td style="min-width: 200px;"><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
-                    <td style="min-width: 140px;">${status_html}</td>
-                    <td style="min-width: 140px;">${priority_html}</td>
-                    <td style="min-width: 150px;">
+                    <td class="dashcol dashcol-project_name project-name-cell" style="min-width: 200px;"><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
+                    <td class="dashcol dashcol-project_id project-id-cell"><a href="/app/project/${p.name}" class="text-muted">${p.name}</a></td>
+                    <td class="dashcol dashcol-status" style="min-width: 140px;">${status_html}</td>
+                    <td class="dashcol dashcol-custom_project_priority" style="min-width: 140px;">${priority_html}</td>
+                    <td class="dashcol dashcol-percent_complete" style="min-width: 150px;">
                         <div class="d-flex align-items-center">
                             <div class="progress flex-grow-1 mr-2" style="height: 10px;">
                                 <div class="progress-bar bg-primary" style="width: ${p.percent_complete || 0}%"></div>
@@ -782,7 +831,7 @@
                             <span class="small font-weight-bold">${Math.round(p.percent_complete || 0)}%</span>
                         </div>
                     </td>
-                    <td style="min-width: 150px;">${p.project_user || "Unassigned"}</td>
+                    <td class="dashcol dashcol-project_user" style="min-width: 150px;">${p.project_user || "Unassigned"}</td>
                 </tr>
             `);
         });
@@ -800,7 +849,8 @@
     function render_active_internal() {
         let container = $root.find('#dashboard-content');
         container.empty();
-        
+        render_column_toolbar(container);
+
         let state = sort_state['active-internal-projects'];
         let internal_projects = project_data.filter(p => p.is_active === "Yes");
 
@@ -833,12 +883,15 @@
             container.append(`<h5 class="mt-4 mb-3 text-muted border-bottom pb-2">${master}</h5>`);
             container.append(build_internal_table(master_projects));
         });
+
+        column_selectors['active-internal-projects'].apply(container);
     }
 
     function render_completed_projects() {
         let container = $root.find('#dashboard-content');
         container.empty();
-        
+        render_column_toolbar(container);
+
         let state = sort_state['completed-projects'];
         let completed_projects = project_data.filter(p => p.is_active === "No");
 
@@ -859,6 +912,7 @@
                 <thead class="thead-light">
                     <tr>
                         ${th('project_name', 'Project Name')}
+                        ${project_id_th}
                         ${th('status', 'Status')}
                         ${th('project_type', 'Type')}
                         ${th('project_user', 'Assigned To')}
@@ -876,10 +930,11 @@
 
             table.find('tbody').append(`
                 <tr>
-                    <td style="min-width: 200px;"><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
-                    <td style="min-width: 120px;"><span class="badge badge-${status_badge}">${p.status}</span></td>
-                    <td style="min-width: 150px;">${p.project_type || "Uncategorized"}</td>
-                    <td style="min-width: 150px;" class="text-muted">${p.project_user || "Unassigned"}</td>
+                    <td class="dashcol dashcol-project_name project-name-cell" style="min-width: 200px;"><a href="/app/project/${p.name}" class="font-weight-bold">${p.project_name}</a></td>
+                    <td class="dashcol dashcol-project_id project-id-cell"><a href="/app/project/${p.name}" class="text-muted">${p.name}</a></td>
+                    <td class="dashcol dashcol-status" style="min-width: 120px;"><span class="badge badge-${status_badge}">${p.status}</span></td>
+                    <td class="dashcol dashcol-project_type" style="min-width: 150px;">${p.project_type || "Uncategorized"}</td>
+                    <td class="dashcol dashcol-project_user text-muted" style="min-width: 150px;">${p.project_user || "Unassigned"}</td>
                 </tr>
             `);
         });
@@ -888,7 +943,10 @@
         wrapper.append(table);
 
         if (completed_projects.length === 0) container.html('<div class="p-4 text-center text-muted">No completed projects found.</div>');
-        else container.append(wrapper);
+        else {
+            container.append(wrapper);
+            column_selectors['completed-projects'].apply(container);
+        }
     }
 
     function render_current_tab() {

--- a/project_enhancements/hooks.py
+++ b/project_enhancements/hooks.py
@@ -43,6 +43,7 @@ app_include_js = [
 	"/assets/project_enhancements/js/lib/frappe-gantt.umd.js",
 	"/assets/project_enhancements/js/gantt_auto_scroll.js",
 	"/assets/project_enhancements/js/task_tree_manager.js",
+	"/assets/project_enhancements/js/dashboard_components/column_selector.js",
 ]
 
 doctype_list_js = {"Task": "project_enhancements/public/js/task_gantt.js"}

--- a/project_enhancements/public/css/task_tree.css
+++ b/project_enhancements/public/css/task_tree.css
@@ -139,3 +139,65 @@
 	white-space: normal;
 	word-break: break-word;
 }
+
+/* --- Dashboard list column selector --- */
+.dashboard-list-toolbar {
+	display: flex;
+	justify-content: flex-end;
+	margin-bottom: 0.5rem;
+}
+
+.dashboard-column-selector {
+	position: relative;
+	display: inline-block;
+}
+
+.column-selector-menu {
+	display: none;
+	position: absolute;
+	right: 0;
+	top: 100%;
+	z-index: 1000;
+	min-width: 200px;
+	max-height: 320px;
+	overflow-y: auto;
+	margin-top: 4px;
+	padding: 6px 0;
+	background-color: #fff;
+	border: 1px solid #d1d8dd;
+	border-radius: 6px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.column-selector-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin: 0;
+	padding: 6px 14px;
+	font-weight: normal;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.column-selector-item:hover {
+	background-color: #f8f9fa;
+}
+
+.column-selector-item input {
+	margin: 0;
+}
+
+/* --- Dashboard list Project Name / Project ID cells --- */
+td.project-name-cell {
+	white-space: normal;
+	word-break: break-word;
+	min-width: 180px;
+	max-width: 320px;
+}
+
+td.project-id-cell {
+	white-space: nowrap;
+	font-family: var(--font-stack-mono, monospace);
+	font-size: 0.85em;
+}

--- a/project_enhancements/public/js/dashboard_components/active_internal_projects.js
+++ b/project_enhancements/public/js/dashboard_components/active_internal_projects.js
@@ -5,6 +5,17 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
 	constructor(wrapper) {
 		this.wrapper = $(wrapper);
 		this.abortController = null;
+		this.columnSelector = new project_enhancements.dashboard_components.ColumnSelector(
+			"project_dashboard_active_internal_columns",
+			[
+				{ key: "project_name", label: "Project Name", locked: true },
+				{ key: "project_id", label: "Project ID" },
+				{ key: "status", label: "Status" },
+				{ key: "priority", label: "Priority" },
+				{ key: "percent_complete", label: "% Complete" },
+				{ key: "assigned_to", label: "Assigned To" },
+			]
+		);
 	}
 
 	async render() {
@@ -58,6 +69,11 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
 			return;
 		}
 
+		const toolbar = $('<div class="dashboard-list-toolbar"></div>').appendTo(this.wrapper);
+		this.columnSelector.render_button(toolbar, () =>
+			this.columnSelector.apply(this.wrapper)
+		);
+
 		const listContainer = $('<div class="frappe-list"></div>').appendTo(this.wrapper);
 
 		// Group by custom_master_project
@@ -92,6 +108,8 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
 			);
 			this.render_table(listContainer, master_projects);
 		});
+
+		this.columnSelector.apply(this.wrapper);
 	}
 
 	render_table(container, projects) {
@@ -99,11 +117,12 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
             <table class="table table-bordered table-hover mb-4">
                 <thead class="thead-light">
                     <tr>
-                        <th>Project Name</th>
-                        <th>Status</th>
-                        <th>Priority</th>
-                        <th>% Complete</th>
-                        <th>Assigned To</th>
+                        <th class="dashcol dashcol-project_name">Project Name</th>
+                        <th class="dashcol dashcol-project_id">Project ID</th>
+                        <th class="dashcol dashcol-status">Status</th>
+                        <th class="dashcol dashcol-priority">Priority</th>
+                        <th class="dashcol dashcol-percent_complete">% Complete</th>
+                        <th class="dashcol dashcol-assigned_to">Assigned To</th>
                     </tr>
                 </thead>
                 <tbody></tbody>
@@ -139,12 +158,15 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
 
 			const row = $(`
                 <tr data-project="${p.name}">
-                    <td><a href="/app/project/${p.name}" class="font-weight-bold">${
-				p.project_name
-			}</a></td>
-                    <td><select class="form-control form-control-sm project-edit" data-field="status">${statusSelect}</select></td>
-                    <td><select class="form-control form-control-sm project-edit" data-field="custom_project_priority">${prioritySelect}</select></td>
-                    <td>
+                    <td class="dashcol dashcol-project_name project-name-cell"><a href="/app/project/${
+						p.name
+					}" class="font-weight-bold">${p.project_name}</a></td>
+                    <td class="dashcol dashcol-project_id project-id-cell"><a href="/app/project/${
+						p.name
+					}" class="text-muted">${p.name}</a></td>
+                    <td class="dashcol dashcol-status"><select class="form-control form-control-sm project-edit" data-field="status">${statusSelect}</select></td>
+                    <td class="dashcol dashcol-priority"><select class="form-control form-control-sm project-edit" data-field="custom_project_priority">${prioritySelect}</select></td>
+                    <td class="dashcol dashcol-percent_complete">
                         <div class="progress" style="height: 10px; border-radius: 4px;">
                             <div class="progress-bar bg-primary" role="progressbar" style="width: ${
 								p.percent_complete || 0
@@ -153,7 +175,9 @@ project_enhancements.dashboard_components.ActiveInternalProjects = class ActiveI
 			}" aria-valuemin="0" aria-valuemax="100"></div>
                         </div>
                     </td>
-                    <td class="text-muted">${p.project_user || "Unassigned"}</td>
+                    <td class="dashcol dashcol-assigned_to text-muted">${
+						p.project_user || "Unassigned"
+					}</td>
                 </tr>
             `);
 

--- a/project_enhancements/public/js/dashboard_components/column_selector.js
+++ b/project_enhancements/public/js/dashboard_components/column_selector.js
@@ -1,0 +1,121 @@
+/* global project_enhancements */
+frappe.provide("project_enhancements.dashboard_components");
+
+/**
+ * Reusable column visibility selector for the dashboard list tables.
+ *
+ * Each table cell (`<th>`/`<td>`) is tagged with `dashcol dashcol-<key>` classes.
+ * This helper renders a "Columns" dropdown of checkboxes and toggles the
+ * `hidden-column` class on the matching cells. The user's choice is persisted
+ * to localStorage under the supplied storage key.
+ */
+project_enhancements.dashboard_components.ColumnSelector = class ColumnSelector {
+	/**
+	 * @param {string} storageKey localStorage key used to persist hidden columns.
+	 * @param {Array<{key: string, label: string, locked?: boolean}>} columns Column definitions.
+	 */
+	constructor(storageKey, columns) {
+		this.storageKey = storageKey;
+		this.columns = columns;
+		this.hidden = this._load();
+	}
+
+	_load() {
+		try {
+			const raw = localStorage.getItem(this.storageKey);
+			const parsed = raw ? JSON.parse(raw) : [];
+			return Array.isArray(parsed) ? parsed : [];
+		} catch (e) {
+			return [];
+		}
+	}
+
+	_save() {
+		try {
+			localStorage.setItem(this.storageKey, JSON.stringify(this.hidden));
+		} catch (e) {
+			// Ignore storage errors (e.g. private browsing mode)
+		}
+	}
+
+	is_hidden(key) {
+		return this.hidden.indexOf(key) !== -1;
+	}
+
+	set_hidden(key, hidden) {
+		const idx = this.hidden.indexOf(key);
+		if (hidden && idx === -1) {
+			this.hidden.push(key);
+		} else if (!hidden && idx !== -1) {
+			this.hidden.splice(idx, 1);
+		}
+		this._save();
+	}
+
+	/** Toggles the `hidden-column` class on all tagged cells within `root`. */
+	apply(root) {
+		this.columns.forEach((col) => {
+			root.find(`.dashcol-${col.key}`).toggleClass("hidden-column", this.is_hidden(col.key));
+		});
+	}
+
+	/**
+	 * Renders the "Columns" dropdown button into `container`.
+	 * @param {JQuery} container Element to append the button to.
+	 * @param {Function} onChange Called after a column is toggled.
+	 */
+	render_button(container, onChange) {
+		const wrapper = $(`
+			<div class="dashboard-column-selector">
+				<button type="button" class="btn btn-sm btn-default column-selector-toggle">
+					<i class="fa fa-columns mr-1"></i> Columns
+				</button>
+				<div class="column-selector-menu"></div>
+			</div>
+		`).appendTo(container);
+
+		const menu = wrapper.find(".column-selector-menu");
+
+		this.columns.forEach((col) => {
+			const checked = this.is_hidden(col.key) ? "" : "checked";
+			const disabled = col.locked ? "disabled" : "";
+			const item = $(`
+				<label class="column-selector-item ${col.locked ? "text-muted" : ""}">
+					<input type="checkbox" data-key="${frappe.utils.escape_html(
+						col.key
+					)}" ${checked} ${disabled}>
+					<span>${frappe.utils.escape_html(col.label)}</span>
+				</label>
+			`);
+			menu.append(item);
+		});
+
+		menu.find("input[type=checkbox]").on("change", (e) => {
+			const cb = $(e.currentTarget);
+			this.set_hidden(cb.data("key"), !cb.prop("checked"));
+			if (typeof onChange === "function") {
+				onChange();
+			}
+		});
+
+		const toggle = wrapper.find(".column-selector-toggle");
+		toggle.on("click", (e) => {
+			e.stopPropagation();
+			const isOpen = menu.is(":visible");
+			// Close any other open column menus first
+			$(".column-selector-menu").hide();
+			if (!isOpen) {
+				menu.show();
+				const closeHandler = (ev) => {
+					if (!$(ev.target).closest(".dashboard-column-selector").length) {
+						menu.hide();
+						$(document).off("click.columnSelector", closeHandler);
+					}
+				};
+				$(document).on("click.columnSelector", closeHandler);
+			}
+		});
+
+		return wrapper;
+	}
+};

--- a/project_enhancements/public/js/dashboard_components/completed_projects.js
+++ b/project_enhancements/public/js/dashboard_components/completed_projects.js
@@ -5,6 +5,16 @@ project_enhancements.dashboard_components.CompletedProjects = class CompletedPro
 	constructor(wrapper) {
 		this.wrapper = $(wrapper);
 		this.abortController = null;
+		this.columnSelector = new project_enhancements.dashboard_components.ColumnSelector(
+			"project_dashboard_completed_columns",
+			[
+				{ key: "project_name", label: "Project Name", locked: true },
+				{ key: "project_id", label: "Project ID" },
+				{ key: "status", label: "Status" },
+				{ key: "project_type", label: "Type" },
+				{ key: "assigned_to", label: "Assigned To" },
+			]
+		);
 	}
 
 	async render() {
@@ -89,16 +99,22 @@ project_enhancements.dashboard_components.CompletedProjects = class CompletedPro
 			return;
 		}
 
+		const toolbar = $('<div class="dashboard-list-toolbar"></div>').appendTo(this.wrapper);
+		this.columnSelector.render_button(toolbar, () =>
+			this.columnSelector.apply(this.wrapper)
+		);
+
 		const listContainer = $('<div class="frappe-list"></div>').appendTo(this.wrapper);
 
 		const table = $(`
             <table class="table table-bordered table-hover">
                 <thead class="thead-light">
                     <tr>
-                        <th>Project Name</th>
-                        <th>Status</th>
-                        <th>Type</th>
-                        <th>Assigned To</th>
+                        <th class="dashcol dashcol-project_name">Project Name</th>
+                        <th class="dashcol dashcol-project_id">Project ID</th>
+                        <th class="dashcol dashcol-status">Status</th>
+                        <th class="dashcol dashcol-project_type">Type</th>
+                        <th class="dashcol dashcol-assigned_to">Assigned To</th>
                     </tr>
                 </thead>
                 <tbody></tbody>
@@ -110,14 +126,21 @@ project_enhancements.dashboard_components.CompletedProjects = class CompletedPro
 		projects.forEach((p) => {
 			const row = $(`
                 <tr data-project="${p.name}">
-                    <td><a href="/app/project/${p.name}" class="font-weight-bold">${
-				p.project_name
-			}</a></td>
-                    <td><span class="badge ${this.get_status_badge(p.status)}">${
-				p.status
-			}</span></td>
-                    <td>${p.project_type || "Uncategorized"}</td>
-                    <td class="text-muted">${p.project_user || "Unassigned"}</td>
+                    <td class="dashcol dashcol-project_name project-name-cell"><a href="/app/project/${
+						p.name
+					}" class="font-weight-bold">${p.project_name}</a></td>
+                    <td class="dashcol dashcol-project_id project-id-cell"><a href="/app/project/${
+						p.name
+					}" class="text-muted">${p.name}</a></td>
+                    <td class="dashcol dashcol-status"><span class="badge ${this.get_status_badge(
+						p.status
+					)}">${p.status}</span></td>
+                    <td class="dashcol dashcol-project_type">${
+						p.project_type || "Uncategorized"
+					}</td>
+                    <td class="dashcol dashcol-assigned_to text-muted">${
+						p.project_user || "Unassigned"
+					}</td>
                 </tr>
             `);
 
@@ -128,6 +151,8 @@ project_enhancements.dashboard_components.CompletedProjects = class CompletedPro
 
 			tbody.append(row);
 		});
+
+		this.columnSelector.apply(this.wrapper);
 	}
 
 	get_status_badge(status) {

--- a/project_enhancements/public/js/dashboard_components/priority_overview.js
+++ b/project_enhancements/public/js/dashboard_components/priority_overview.js
@@ -188,6 +188,17 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 		this.bufferManager = new project_enhancements.dashboard_components.BufferManager(this);
 		this.projectPriorityOptions = [];
 		this.companyPriorityOptions = [];
+		this.columnSelector = new project_enhancements.dashboard_components.ColumnSelector(
+			"project_dashboard_priority_columns",
+			[
+				{ key: "project_name", label: "Project Name", locked: true },
+				{ key: "project_id", label: "Project ID" },
+				{ key: "custom_company_priority", label: "Company Priority" },
+				{ key: "custom_project_priority", label: "Project Priority" },
+				{ key: "completion", label: "Completion Percentage" },
+				{ key: "spend_percent", label: "Spend %" },
+			]
+		);
 	}
 
 	set_view(view) {
@@ -282,6 +293,11 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 			return;
 		}
 
+		const toolbar = $('<div class="dashboard-list-toolbar"></div>').appendTo(this.wrapper);
+		this.columnSelector.render_button(toolbar, () =>
+			this.columnSelector.apply(this.wrapper)
+		);
+
 		const listContainer = $('<div class="frappe-list"></div>').appendTo(this.wrapper);
 
 		if (this.current_view === "company_priority") {
@@ -339,6 +355,8 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 				this.render_table(listContainer, stream_projects);
 			});
 		}
+
+		this.columnSelector.apply(this.wrapper);
 	}
 
 	render_table(container, projects) {
@@ -346,11 +364,12 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
             <table class="table table-bordered table-hover mb-4">
                 <thead class="thead-light">
                     <tr>
-                        <th>Project Name</th>
-                        <th>Company Priority</th>
-                        <th>Project Priority</th>
-                        <th>Completion Percentage</th>
-                        <th>Project Budget Health</th>
+                        <th class="dashcol dashcol-project_name">Project Name</th>
+                        <th class="dashcol dashcol-project_id">Project ID</th>
+                        <th class="dashcol dashcol-custom_company_priority">Company Priority</th>
+                        <th class="dashcol dashcol-custom_project_priority">Project Priority</th>
+                        <th class="dashcol dashcol-completion">Completion Percentage</th>
+                        <th class="dashcol dashcol-spend_percent">Spend %</th>
                     </tr>
                 </thead>
                 <tbody></tbody>
@@ -370,20 +389,25 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 					? this.bufferManager.getPendingValue(p.name, "custom_project_priority")
 					: p.custom_project_priority;
 
-			let budget_health = (p.custom_project_dollar_amount || 0) - (p.estimated_costing || 0);
-			let budget_health_formatted = frappe.format(budget_health, { fieldtype: "Currency" });
-			let budget_color = budget_health >= 0 ? "text-success" : "text-danger";
+			let total_budget = p.custom_project_dollar_amount || 0;
+			let spend = p.estimated_costing || 0;
+			let spend_percent = total_budget ? (spend / total_budget) * 100 : 0;
+			let spend_percent_formatted = total_budget ? `${Math.round(spend_percent)}%` : "—";
+			let spend_color = spend_percent > 100 ? "text-danger" : "text-success";
 
 			let completion = p.percent_complete || 0;
 
 			const row = $(`
                 <tr>
-                    <td><a href="/app/project/${
+                    <td class="dashcol dashcol-project_name project-name-cell"><a href="/app/project/${
 						p.name
 					}" class="font-weight-bold project-link" data-name="${p.name}">${
 				p.project_name
 			}</a></td>
-                    <td class="editable-cell priority-cell" data-field="custom_company_priority" data-project="${
+                    <td class="dashcol dashcol-project_id project-id-cell"><a href="/app/project/${
+						p.name
+					}" class="text-muted project-link" data-name="${p.name}">${p.name}</a></td>
+                    <td class="dashcol dashcol-custom_company_priority editable-cell priority-cell" data-field="custom_company_priority" data-project="${
 						p.name
 					}">
                         <div class="static-view" style="cursor: pointer;" title="Click to edit">
@@ -393,7 +417,7 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
                             <select class="form-control form-control-sm"></select>
                         </div>
                     </td>
-                    <td class="editable-cell priority-cell" data-field="custom_project_priority" data-project="${
+                    <td class="dashcol dashcol-custom_project_priority editable-cell priority-cell" data-field="custom_project_priority" data-project="${
 						p.name
 					}">
                         <div class="static-view" style="cursor: pointer;" title="Click to edit">
@@ -403,7 +427,7 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
                             <select class="form-control form-control-sm"></select>
                         </div>
                     </td>
-                    <td style="min-width: 150px;">
+                    <td class="dashcol dashcol-completion" style="min-width: 150px;">
                         <div class="d-flex align-items-center">
                             <div class="progress flex-grow-1 mr-2" style="height: 10px;">
                                 <div class="progress-bar ${
@@ -413,7 +437,7 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
                             <span class="small font-weight-bold">${Math.round(completion)}%</span>
                         </div>
                     </td>
-                    <td class="font-weight-bold ${budget_color}">${budget_health_formatted}</td>
+                    <td class="dashcol dashcol-spend_percent font-weight-bold ${spend_color}">${spend_percent_formatted}</td>
                 </tr>
             `);
 
@@ -491,7 +515,7 @@ project_enhancements.dashboard_components.PriorityOverview = class PriorityOverv
 			row.data("custom_project_priority", display_project_priority);
 			row.data("custom_company_priority", display_company_priority);
 			row.data("percent_complete", completion);
-			row.data("budget_health", budget_health);
+			row.data("spend_percent", spend_percent);
 
 			tbody.append(row);
 		});


### PR DESCRIPTION
## What changed

Three enhancements to the project dashboard lists, applied to **both** dashboard implementations (the page-based `project_dashboard` components and the parallel `Custom HTML Block/projects_dashboard.js`):

1. **Project ID column** — Every list (Priority Overview, Active Internal Projects, Completed Projects) now shows the `PRJ-#####` ID as a linked, monospace cell beside the Project Name.
2. **Selectable columns** — A new "Columns" dropdown lets users show/hide columns per list. Choices persist in `localStorage`. Backed by a new shared `ColumnSelector` helper (`dashboard_components/column_selector.js`), registered in `app_include_js` so it loads globally.
3. **Project Name wrapping** — Long project names now wrap instead of forcing wide columns.
4. **Spend % replaces Budget Health** — The Priority Overview's "Budget Health" dollar delta is replaced with **Spend %** = `estimated_costing / custom_project_dollar_amount * 100`. Green at/under budget, red when over, em-dash when no budget is set. Sorting updated accordingly.

## Why

Gives users at-a-glance project IDs, control over which columns they see, readable long names, and a more meaningful budget signal: proportional spend rather than a raw dollar difference.

## Reviewer notes

- **Deployment:** A `bench build` / cache clear is required to pick up the new asset and the `hooks.py` `app_include_js` change.
- **Column key rename:** `budget_health` to `spend_percent` throughout. Anyone who had previously hidden the old "Budget Health" column will see "Spend %" visible again (persisted under a new localStorage key).
- The `ColumnSelector` tags each `<th>`/`<td>` with `dashcol dashcol-<key>` classes and toggles the existing `hidden-column` CSS class; visibility is re-applied after every re-render so it survives sorts, view switches, and inline-edit commits.
- No backend/Python changes — all data fields (`name`, `estimated_costing`, `custom_project_dollar_amount`) were already returned by `get_project_data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
