### PR TITLE
Fix Projects Dashboard block failing to load (undefined ColumnSelector)

### DIFF
--- a/Custom HTML Block/projects_dashboard.js
+++ b/Custom HTML Block/projects_dashboard.js
@@ -1,4 +1,11 @@
 (function() {
+    // The ColumnSelector class lives in a separate asset registered via app_include_js.
+    // Don't assume that bundle has already executed when this block renders — load it
+    // explicitly so the dashboard works regardless of asset load order / build state.
+    frappe.provide("project_enhancements.dashboard_components");
+    frappe.require("/assets/project_enhancements/js/dashboard_components/column_selector.js", init_dashboard);
+
+    function init_dashboard() {
     const $root = $(root_element);
 
     let current_tab = "priority-overview";
@@ -1002,4 +1009,5 @@
 
     // Init
     fetch_initial_data();
+    }
 })();


### PR DESCRIPTION
@
## What

The **Projects Dashboard** Custom HTML Block was rendering its tabs (Priority Overview, Active Internal, Completed, Portfolio Gantt) but loading no content, throwing:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'ColumnSelector')
```

## Why

The block script read `project_enhancements.dashboard_components.ColumnSelector` at module top level, assuming `column_selector.js` (registered in `app_include_js`) had already executed. When that bundle had not yet run at block-render time, the namespace was `undefined`, the `TypeError` aborted the entire script, and nothing populated.

The sibling Frappe **page** version doesn't make that assumption — it loads each component with `frappe.require` before use. This change brings the block in line with that pattern.

## Change

- Wrap the block's init logic in `frappe.require("/assets/project_enhancements/js/dashboard_components/column_selector.js", ...)` so the dependency is guaranteed loaded before `ColumnSelector` is referenced.
- Add a defensive `frappe.provide("project_enhancements.dashboard_components")`.

`frappe.require` fast-paths when the asset is already loaded, so there's no double-load cost. Validated with `node --check`.

## Reviewer notes

- This `Custom HTML Block/` folder is a working copy, **not** a Frappe fixture. To deploy, the updated script must be pasted into the actual *Projects Dashboard* Custom HTML Block doc in the instance, and `bench build` should be run so `column_selector.js` is served under `/assets/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@