### PR TITLE
Auto-load Tasks Tree and hide View Tasks button on Project

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -62,8 +62,12 @@ frappe.ui.form.on("Project", {
 							original_refresh.call(this);
 						}
 
-						// By the time this runs, the tab has been clicked and this.$wrapper is guaranteed to exist
-						if (this.$wrapper && this.$wrapper.children().length === 0) {
+						// By the time this runs, the tab has been clicked and this.$wrapper is guaranteed to exist.
+						// Guard on our own injected marker (.task-tree-container) rather than a raw
+						// children() count: a Frappe HTML control's $wrapper already contains internal
+						// label/input structure after original_refresh, so children().length is never 0
+						// and the tree would otherwise never render.
+						if (this.$wrapper && this.$wrapper.find(".task-tree-container").length === 0) {
 							const docName = frm.doc.name;
 
 							frappe
@@ -219,7 +223,9 @@ frappe.ui.form.on("Project", {
 			styleEl.id = styleId;
 			styleEl.innerHTML = `
                 .inner-group-button[data-label="View"],
-                .custom-btn-group[data-label="View"] {
+                .custom-btn-group[data-label="View"],
+                .inner-group-button[data-label="View Tasks"],
+                .custom-btn-group[data-label="View Tasks"] {
                     display: none !important;
                 }
             `;
@@ -235,141 +241,5 @@ frappe.ui.form.on("Project", {
 				}
 			}
 		}, 100);
-
-		// =========================================================================
-		// 6. CUSTOM "VIEW TASKS" DROPDOWN
-		// =========================================================================
-		if (frappe.has_permission("Task", "read")) {
-			// Helper to wait for an element without hardcoded timeouts
-			const waitForElement = (selector, timeout = 3000) => {
-				return new Promise((resolve, reject) => {
-					if (document.querySelector(selector)) {
-						return resolve(document.querySelector(selector));
-					}
-
-					const observer = new MutationObserver(() => {
-						if (document.querySelector(selector)) {
-							observer.disconnect();
-							resolve(document.querySelector(selector));
-						}
-					});
-
-					observer.observe(document.body, {
-						childList: true,
-						subtree: true
-					});
-
-					setTimeout(() => {
-						observer.disconnect();
-						reject(new Error(`Timeout waiting for element: ${selector}`));
-					}, timeout);
-				});
-			};
-
-			// Create parent dropdown first
-			frm.add_custom_button(
-				__("Calendar"),
-				async function () {
-					frappe.dom.freeze(__("Navigating to Calendar View..."));
-					try {
-						frappe.route_options = { project: frm.doc.name };
-						await frappe.set_route("List", "Task", "Calendar");
-					} catch (error) {
-						frappe.msgprint({
-							title: __("Error"),
-							message: __("Failed to navigate to Calendar View."),
-							indicator: "red",
-						});
-					} finally {
-						frappe.dom.unfreeze();
-					}
-				},
-				__("View Tasks")
-			);
-
-			// Yield execution then check if parent rendered, followed by adding the remaining options
-			setTimeout(() => {
-				waitForElement('.inner-group-button[data-label="View Tasks"], .custom-btn-group[data-label="View Tasks"]')
-					.then((dropdownGroupEl) => {
-						frm.add_custom_button(
-							__("Kanban"),
-							async function () {
-								frappe.dom.freeze(__("Navigating to Kanban Board..."));
-								try {
-									frappe.route_options = { project: frm.doc.name };
-									await frappe.set_route("List", "Task", "Kanban");
-								} catch (error) {
-									frappe.msgprint({
-										title: __("Error"),
-										message: __("Failed to navigate to Kanban Board."),
-										indicator: "red",
-									});
-								} finally {
-									frappe.dom.unfreeze();
-								}
-							},
-							__("View Tasks")
-						);
-
-						frm.add_custom_button(
-							__("Gantt"),
-							function () {
-								console.log("View Tasks > Gantt clicked - routing to tab.");
-								// Go to Schedule tab specifically
-								window.location.hash = "#custom_schedule";
-								setTimeout(() => {
-									const scheduleTab = frm.$wrapper.find(
-										'.form-tabs .nav-item[data-label="Schedule"], .form-tabs .nav-item[data-fieldname="custom_schedule"]'
-									);
-									if (scheduleTab.length) {
-										const tabLink = scheduleTab.find("a.nav-link");
-										if (tabLink.length) {
-											tabLink.click();
-										} else {
-											scheduleTab.click();
-										}
-									}
-									
-									// Scroll down to the chart section after tab transition
-									setTimeout(() => {
-										frm.scroll_to_field("custom_gantt_chart_section");
-									}, 200);
-								}, 100);
-							},
-							__("View Tasks")
-						);
-
-						frm.add_custom_button(
-							__("Tree View"),
-							function () {
-								window.location.hash = "#custom_scope";
-								setTimeout(() => {
-									const scopeTab = frm.$wrapper.find(
-										'.form-tabs .nav-item[data-label="Scope"], .form-tabs .nav-item[data-fieldname="custom_scope"]'
-									);
-									if (scopeTab.length) {
-										const tabLink = scopeTab.find("a.nav-link");
-										if (tabLink.length) {
-											tabLink.click();
-										} else {
-											scopeTab.click();
-										}
-									}
-								}, 100);
-							},
-							__("View Tasks")
-						);
-
-						// Style parent button
-						const btnGroup = $(dropdownGroupEl).find('button').first();
-						if (btnGroup.length) {
-							btnGroup.removeClass("btn-default").addClass("btn-primary");
-						}
-					})
-					.catch((err) => {
-						console.error(err);
-					});
-			}, 0);
-		}
 	},
 });


### PR DESCRIPTION
## What changed

**1. Tasks Tree now auto-loads on the Project Scope tab**

The tree never rendered because its render guard in `project_form_script.js` checked `this.$wrapper.children().length === 0`. For a Frappe HTML control, `$wrapper` is the `.frappe-control` element, which already contains internal label/input structure after the native `refresh()` runs — so that count is essentially never `0`, and the tree-render block was skipped on every refresh (auto-load poll, `shown.bs.tab`, and manual Scope-tab clicks alike).

The guard now checks for the tree's own injected marker (`.task-tree-container`), mirroring the proven-working Gantt field guard (`project.js`, which checks `.gantt-chart-container`). This is idempotent — the marker is found on subsequent refreshes, so no duplicate trees or leaked Sortable instances.

**2. Hidden the "View Tasks" button**

- Removed the custom "View Tasks" dropdown creation (former section 6) so the repo no longer adds it.
- Extended the existing hide-button CSS to also suppress `[data-label="View Tasks"]`, covering any button created by the legacy DB client script (`project__custom_js`).

## Why

The tree auto-load was the intent of the prior "Auto-load Tasks Tree View" commit but the guard prevented it from ever firing. With the tree now loading on the Scope tab and the Gantt living on the Schedule tab, the redundant "View Tasks" dropdown was requested to be hidden.

## Reviewer notes

- JS asset change — requires `bench build --app project_enhancements && bench clear-cache` and a hard reload to take effect.
- Kanban/Calendar views remain reachable from the Task list; Gantt is on the Schedule tab; tree is on the Scope tab.
- The section-5 comment still reads "HIDE STANDARD VIEW BUTTON" though it now also hides "View Tasks" — left as-is intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)