### PR TITLE
Fix doctype_js path so project_form_script.js actually loads

### DIFF
--- a/project_enhancements/hooks.py
+++ b/project_enhancements/hooks.py
@@ -19,7 +19,7 @@ app_license = "mit"
 doctype_js = {
 	"Project": [
 		"project_enhancements/doctype/project/project.js",
-		"project_enhancements/public/js/project_form_script.js",
+		"public/js/project_form_script.js",
 	],
 	"Opportunity": "project_enhancements/doctype/opportunity/opportunity.js",
 	"Address": "project_enhancements/doctype/address/address.js",


### PR DESCRIPTION
## The real root cause

PR #167 fixed the tree-render logic and removed the View Tasks dropdown — but **none of it ran on the live site**, because `project_form_script.js` was never being loaded at all.

### Evidence
Across every deploy, the console showed `project.js` logging ("initializing Gantt check") but **zero** output from `project_form_script.js` (no "Cleaning up old tree state", no "Rendering Task Tree for Project"). The file was registered in the `doctype_js` hook, but its path didn't resolve.

### Why
`doctype_js` paths resolve relative to the app's **package dir** (where `hooks.py` lives). The layout is:

```
project_enhancements/                 <- package dir (hooks.py here)
  public/js/project_form_script.js    <- actual file
  project_enhancements/               <- nested module folder
    doctype/project/project.js        <- actual file
```

The hook had:
```python
"project_enhancements/public/js/project_form_script.js"
```
which resolves to `project_enhancements/project_enhancements/public/js/project_form_script.js` — **a path that does not exist** (there is no `public/` under the nested module folder). Frappe silently skips unresolvable paths, so the script never loaded.

`project.js` kept working because its path (`project_enhancements/doctype/project/project.js`) points under the nested module folder, which **is** correct.

### Fix
Drop the erroneous `project_enhancements/` prefix:
```python
"public/js/project_form_script.js"
```

## Result
With the script now loading, the merged fixes from #167 take effect: the Tasks Tree auto-loads on the Scope tab and the repo no longer adds a View Tasks button.

## Reviewer notes
- Requires `bench build --app project_enhancements && bench clear-cache` + hard reload (or a Frappe Cloud redeploy) to take effect.
- After deploy, the console should now show `Rendering Task Tree for Project: <name>`. That line is the confirmation the script is finally loading.
- Separately: a legacy DB **Client Script** (`project__custom_js`) still logs "Sapphire Fountains: Project dashboard found and hidden." It's unrelated to this fix but worth retiring into the repo or deleting to avoid future divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)