### PR TITLE
Fix client-side permission check that blocked the Tasks Tree

### DIFF
--- a/project_enhancements/public/js/project_form_script.js
+++ b/project_enhancements/public/js/project_form_script.js
@@ -48,7 +48,9 @@ frappe.ui.form.on("Project", {
 		// =========================================================================
 		// 3. TREE VIEW RENDERER
 		// =========================================================================
-		if (frappe.has_permission("Task", "read")) {
+		// Note: frappe.has_permission is a server-side (Python) API and does not
+		// exist on the client. Use frappe.model.can_read for the desk-side check.
+		if (frappe.model.can_read("Task")) {
 			const wrapperField = frm.get_field("custom_tasks_html");
 
 			if (wrapperField) {


### PR DESCRIPTION
## Progress so far

- #167 fixed the tree render guard and removed the View Tasks dropdown.
- #168 fixed the `doctype_js` path so `project_form_script.js` finally loads.
- **This PR** fixes the next error exposed once the script actually ran.

## The error

With the script now loading, the console showed it run (`Project form refreshed: PRJ-00706. Cleaning up old tree state`) and then immediately throw:

```
Uncaught (in promise) TypeError: frappe.has_permission is not a function
    at refresh (project__js:529)
```

## Cause

Section 3 (the Tree View renderer) guarded itself with:
```js
if (frappe.has_permission("Task", "read")) { ... }
```
`frappe.has_permission` is a **server-side (Python)** API — it does not exist on the client. On this ERPNext v16 build the call throws, and the exception aborts the refresh handler *before* the tree-render logic runs. So the tree never appeared.

## Fix

Use the standard desk-side check:
```js
if (frappe.model.can_read("Task")) { ... }
```

The `frappe.has_permission(...)` calls in `project_dashboard.py` are server-side and remain correct — untouched.

## Result

After deploy, the refresh handler runs to completion and the Tasks Tree auto-loads on the Scope tab.

## Reviewer notes
- Requires `bench build --app project_enhancements && bench clear-cache` + hard reload (or Frappe Cloud redeploy).
- Expected console after deploy: `Rendering Task Tree for Project: <name>` with no `frappe.has_permission` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)