### PR TITLE
Fix Tasks Tree sub-tasking crash (SortableJS _onDrop null error)

### DIFF
--- a/project_enhancements/public/js/task_tree_manager.js
+++ b/project_enhancements/public/js/task_tree_manager.js
@@ -608,34 +608,48 @@ project_enhancements.TaskTreeManager = class TaskTreeManager {
 
 	handleDragEnd(evt) {
 		this.clearDropIndicators();
+		const me = this;
 		const draggedNode = evt.item;
-		let changed = evt.from !== evt.to || evt.oldIndex !== evt.newIndex;
-
-		if (this._dropMode === "child" && this._dropTargetId) {
-			const $target = this.wrapper.find(`.task-node[data-task-id="${this._dropTargetId}"]`).first();
-			if ($target.length && !$.contains(draggedNode, $target[0]) && $target[0] !== draggedNode) {
-				let $childContainer = $target.children(".child-tasks-container");
-				if (!$childContainer.length) {
-					$childContainer = $('<div class="child-tasks-container"></div>').appendTo($target);
-				}
-				// Drop a placeholder/"No subtasks." message if present, then nest.
-				$childContainer.children(".text-muted").remove();
-				$childContainer.show().append(draggedNode);
-				// Reflect the now-expanded parent so the re-render keeps it open.
-				const $icon = $target.children(".task-grid-row").find(".fa-circle, .toggle-child-tasks").first();
-				$icon.removeClass("fa-circle text-extra-muted fa-caret-right").addClass("fa-caret-down toggle-child-tasks");
-				$target.attr("data-loaded", "true").data("loaded", "true");
-				this.expandedTasks.add(this._dropTargetId);
-				localStorage.setItem(`expandedTasks_${this.projectName}`, JSON.stringify(Array.from(this.expandedTasks)));
-				changed = true;
-			}
-		}
+		const mode = this._dropMode;
+		const targetId = this._dropTargetId;
+		const reordered = evt.from !== evt.to || evt.oldIndex !== evt.newIndex;
 
 		this._dropMode = null;
 		this._dropTargetId = null;
 
-		// Persist immediately so the tree re-indents itself without a manual save.
-		if (changed) this.saveTaskOrder();
+		// CRITICAL: never mutate the DOM synchronously inside onEnd. SortableJS is
+		// still in the middle of its own drop cleanup when this fires; re-parenting
+		// the dragged node here leaves its internals pointing at a detached element
+		// and throws inside Sortable.min.js _onDrop:
+		//   "Cannot read properties of null (reading 'removeEventListener')".
+		// Deferring to the next tick lets Sortable finish first, then we re-parent
+		// on a clean DOM and persist.
+		setTimeout(() => {
+			let changed = reordered;
+
+			if (mode === "child" && targetId) {
+				const $target = me.wrapper.find(`.task-node[data-task-id="${targetId}"]`).first();
+				if ($target.length && !$.contains(draggedNode, $target[0]) && $target[0] !== draggedNode) {
+					let $childContainer = $target.children(".child-tasks-container");
+					if (!$childContainer.length) {
+						$childContainer = $('<div class="child-tasks-container"></div>').appendTo($target);
+					}
+					// Drop a placeholder/"No subtasks." message if present, then nest.
+					$childContainer.children(".text-muted").remove();
+					$childContainer.show().append(draggedNode);
+					// Reflect the now-expanded parent so the re-render keeps it open.
+					const $icon = $target.children(".task-grid-row").find(".fa-circle, .toggle-child-tasks").first();
+					$icon.removeClass("fa-circle text-extra-muted fa-caret-right").addClass("fa-caret-down toggle-child-tasks");
+					$target.attr("data-loaded", "true").data("loaded", "true");
+					me.expandedTasks.add(targetId);
+					localStorage.setItem(`expandedTasks_${me.projectName}`, JSON.stringify(Array.from(me.expandedTasks)));
+					changed = true;
+				}
+			}
+
+			// Persist so the tree re-indents itself (saveTaskOrder re-fetches).
+			if (changed) me.saveTaskOrder();
+		}, 0);
 	}
 
 	saveTaskOrder() {


### PR DESCRIPTION
## Summary

Fixes the Tasks Tree View so dragging a task **onto** another task nests it as a subtask. Previously only reordering worked; attempting to nest threw `Uncaught TypeError: Cannot read properties of null (reading 'removeEventListener')` inside `Sortable.min.js _onDrop`, and the nesting never took effect.

## Root cause

`handleDragEnd` (the SortableJS `onEnd` callback) re-parented the dragged DOM node **synchronously**. SortableJS is still finishing its own drop cleanup when `onEnd` fires, so moving the element it was tracking left its internals pointing at a detached node and crashed in `_onDrop` after `onEnd` returned (which is why the stack trace contains **no app frame**).

Reordering never crashed because that path mutates nothing in `onEnd` — only the nest path moved the node, and the crash aborted the nest before it could persist. That's exactly the reported behavior: reorder works, nest doesn't.

## Fix

Defer all DOM mutation and the save to the next tick (`setTimeout(…, 0)`), so SortableJS completes its `_onDrop` cleanup first. The dragged node is then re-parented on a clean DOM and persisted via `saveTaskOrder` (which re-fetches and re-renders). Drag-intent detection (middle band = nest, top/bottom edge = reorder) is unchanged.

## Reviewer notes

- Single file changed: `project_enhancements/public/js/task_tree_manager.js`.
- Requires `bench build` + hard refresh to take effect.
- The deferred-mutation pattern is the standard remedy for SortableJS `onEnd` re-parenting crashes.

## Test Plan

- [ ] Drag a task onto the **middle** of another task's row → it nests as a subtask, parent auto-expands and indents, no console error
- [ ] Drag a task onto a row's **top/bottom edge** → it reorders as a sibling
- [ ] Drag a parent onto one of its own descendants → rejected (no cycle)
- [ ] Confirm the nesting persists after a page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)