### PR TITLE
Improve Gantt UX: scroll to earliest task, viewport-fit height, +/− zoom controls

### DIFF
--- a/project_enhancements/hooks.py
+++ b/project_enhancements/hooks.py
@@ -46,6 +46,9 @@ app_include_js = [
 	# the per-instance scroll logic (today on first render, preserve on edits).
 	"/assets/project_enhancements/js/task_tree_manager.js",
 	"/assets/project_enhancements/js/dashboard_components/column_selector.js",
+	# Shared Gantt zoom ladder used by the Project form Schedule tab and the
+	# Project Dashboard portfolio Gantt.
+	"/assets/project_enhancements/js/gantt_zoom.js",
 ]
 
 doctype_list_js = {"Task": "project_enhancements/public/js/task_gantt.js"}

--- a/project_enhancements/project_enhancements/doctype/project/project.js
+++ b/project_enhancements/project_enhancements/doctype/project/project.js
@@ -66,8 +66,10 @@ frappe.ui.form.on("Project", {
 							}
 						}
 						if (gantt_wrapper.find(".gantt-chart-container").length === 0) {
-							gantt_wrapper.css({ height: "550px", display: "flex", "flex-direction": "column", border: "1px solid #d1d8dd", "border-radius": "4px", "background-color": "#f8f9fa", "margin-bottom": "20px" });
-							gantt_wrapper.empty().html(`<div class="gantt-toolbar d-flex justify-content-between p-2 bg-light border-bottom"><div class="export-actions"><button type="button" class="btn btn-default btn-sm btn-export-gantt"><i class="fa fa-camera mr-1"></i> Export PNG</button></div><div class="btn-group btn-group-sm view-mode-group"><button type="button" class="btn btn-default" data-view="Quarter Day">Quarter Day</button><button type="button" class="btn btn-default" data-view="Half Day">Half Day</button><button type="button" class="btn btn-primary active" data-view="Day">Day</button><button type="button" class="btn btn-default" data-view="Week">Week</button><button type="button" class="btn btn-default" data-view="Month">Month</button></div></div><div class="gantt-chart-container" style="flex-grow: 1; overflow: hidden;"><p class="text-muted">Initializing Gantt Chart...</p></div><div class="resource-heatmap-container border-top" style="height: 150px; display: none;"><div class="heatmap-header p-2 bg-light d-flex justify-content-between"><span class="small font-weight-bold text-muted">RESOURCE ALLOCATION (HRS/DAY)</span><div class="heatmap-legend d-flex small align-items-center"><span class="mr-2"><i class="fa fa-square text-success"></i> < 6</span><span class="mr-2"><i class="fa fa-square text-warning"></i> 6-9</span><span><i class="fa fa-square text-danger"></i> > 9</span></div></div><div class="heatmap-body" style="overflow: auto; height: 110px;"></div></div>`);
+							const wrapper_top = gantt_wrapper[0].getBoundingClientRect().top;
+							const gantt_height = Math.max(300, window.innerHeight - wrapper_top - 24);
+							gantt_wrapper.css({ height: gantt_height + "px", display: "flex", "flex-direction": "column", border: "1px solid #d1d8dd", "border-radius": "4px", "background-color": "#f8f9fa", "margin-bottom": "20px" });
+							gantt_wrapper.empty().html(`<div class="gantt-toolbar d-flex justify-content-between p-2 bg-light border-bottom"><div class="export-actions"><button type="button" class="btn btn-default btn-sm btn-export-gantt"><i class="fa fa-camera mr-1"></i> Export PNG</button></div><div class="d-flex align-items-center"><div class="btn-group btn-group-sm zoom-mode-group mr-2"><button type="button" class="btn btn-default btn-zoom-out" title="Zoom out (show more)"><i class="fa fa-search-minus"></i></button><button type="button" class="btn btn-default btn-zoom-in" title="Zoom in (show detail)"><i class="fa fa-search-plus"></i></button></div><div class="btn-group btn-group-sm view-mode-group"><button type="button" class="btn btn-default" data-view="Quarter Day">Quarter Day</button><button type="button" class="btn btn-default" data-view="Half Day">Half Day</button><button type="button" class="btn btn-primary active" data-view="Day">Day</button><button type="button" class="btn btn-default" data-view="Week">Week</button><button type="button" class="btn btn-default" data-view="Month">Month</button></div></div></div><div class="gantt-chart-container" style="flex-grow: 1; overflow: hidden;"><p class="text-muted">Initializing Gantt Chart...</p></div><div class="resource-heatmap-container border-top" style="height: 150px; display: none;"><div class="heatmap-header p-2 bg-light d-flex justify-content-between"><span class="small font-weight-bold text-muted">RESOURCE ALLOCATION (HRS/DAY)</span><div class="heatmap-legend d-flex small align-items-center"><span class="mr-2"><i class="fa fa-square text-success"></i> < 6</span><span class="mr-2"><i class="fa fa-square text-warning"></i> 6-9</span><span><i class="fa fa-square text-danger"></i> > 9</span></div></div><div class="heatmap-body" style="overflow: auto; height: 110px;"></div></div>`);
 						}
 						const chart_container = gantt_wrapper.find(".gantt-chart-container");
 						const heatmap_container = gantt_wrapper.find(".resource-heatmap-container");
@@ -90,11 +92,19 @@ frappe.ui.form.on("Project", {
 									if (tasks.length === 0) { chart_container.html('<p class="text-muted text-center p-4">No tasks found for this project.</p>'); return; }
 									wrapperField.render_heatmap(frm, heatmap_container);
 									let clickTimer = null;
+									// Zoom level persists across in-place refreshes within the session
+									// (e.g. dragging a bar) but resets to the default on a fresh page load.
+									const ZOOM = project_enhancements.gantt_zoom;
+									if (typeof wrapperField.__zoom_index !== "number") {
+										wrapperField.__zoom_index = ZOOM.DEFAULT_INDEX.Day;
+									}
+									const zoom_level = ZOOM.level(wrapperField.__zoom_index);
 									const options = {
-										// On a preserve refresh, suppress the library's scroll-to-today
+										// On a preserve refresh, suppress the library's scroll-to-start
 										// so our manual restore (below) is the only thing that moves the
-										// viewport. On a normal render, let the library center on today.
-										view_mode: "Day", scroll_to: preserveScroll ? null : "today",
+										// viewport. On a normal render, scroll to the start of the timeline
+										// so the earliest task is immediately visible.
+										view_mode: zoom_level.view_mode, column_width: zoom_level.column_width, scroll_to: preserveScroll ? null : "start",
 										custom_popup_html: (task) => { let b_info = task.baseline_start ? `<p><span class="popup-label">Baseline:</span> ${moment(task.baseline_start).format('MMM D')} - ${moment(task.baseline_end).format('MMM D')}</p>` : ""; return `<div class="custom-gantt-popup"><h5>${task.name} ${task.is_milestone ? '<span class="badge badge-warning">Milestone</span>' : ''}</h5><p><span class="popup-label">Assignee:</span> ${task.assigned_to || 'Unassigned'}</p><p><span class="popup-label">Status:</span> ${task.status || 'N/A'}</p><p><span class="popup-label">Start:</span> ${moment(task.start).format('MMM D, YYYY')}</p><p><span class="popup-label">End:</span> ${moment(task.end).format('MMM D, YYYY')}</p>${b_info}<p><span class="popup-label">Progress:</span> ${task.progress}%</p><p style="font-size: 11px; margin-top: 8px; color: #777;"><em>Double-click bar to open task</em></p></div>`; },
 										on_click: (task) => { if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; frappe.set_route("Form", "Task", task.id); } else { clickTimer = setTimeout(() => { clickTimer = null; }, 250); } },
 										on_date_change: (task, start, end) => { frappe.call({ method: "project_enhancements.project_enhancements.page.project_dashboard.project_dashboard.update_task_dates_from_gantt", args: { task_name: task.id, start_date: moment(start).format("YYYY-MM-DD"), end_date: moment(end).format("YYYY-MM-DD") }, callback: (res) => { if (res.message && res.message.status === "success") { wrapperField.__preserve_scroll = true; wrapperField.refresh(); wrapperField.render_health_indicator(frm); } } }); },
@@ -104,7 +114,29 @@ frappe.ui.form.on("Project", {
 									if (typeof Gantt === "undefined") { chart_container.html('<p class="text-danger">Gantt library not loaded. Please refresh the page.</p>'); return; }
 									try {
 										const gantt = new Gantt(chart_container[0], tasks, options);
-										gantt_wrapper.find('.view-mode-group button').off('click').on('click', function() { gantt_wrapper.find('.view-mode-group button').removeClass('active btn-primary').addClass('btn-default'); $(this).addClass('active btn-primary').removeClass('btn-default'); gantt.change_view_mode($(this).data('view')); setTimeout(setup_dependency_linking, 100); });
+										// Toolbar sync: highlight the view-mode button matching the current
+										// zoom level and disable the +/- buttons at the ends of the ladder.
+										const sync_zoom_toolbar = () => {
+											const lvl = ZOOM.level(wrapperField.__zoom_index);
+											gantt_wrapper.find('.view-mode-group button').removeClass('active btn-primary').addClass('btn-default');
+											gantt_wrapper.find('.view-mode-group button[data-view="' + lvl.view_mode + '"]').addClass('active btn-primary').removeClass('btn-default');
+											gantt_wrapper.find('.btn-zoom-out').prop('disabled', ZOOM.is_min(wrapperField.__zoom_index));
+											gantt_wrapper.find('.btn-zoom-in').prop('disabled', ZOOM.is_max(wrapperField.__zoom_index));
+										};
+										const apply_zoom = (index) => {
+											wrapperField.__zoom_index = ZOOM.apply(gantt, index);
+											sync_zoom_toolbar();
+											setTimeout(setup_dependency_linking, 100);
+										};
+										// Discrete view-mode buttons jump to that mode's base zoom level so the
+										// +/- buttons stay coherent afterwards (and use the correct column width).
+										gantt_wrapper.find('.view-mode-group button').off('click').on('click', function() {
+											const base = ZOOM.BASE_INDEX[$(this).data('view')];
+											apply_zoom(typeof base === "number" ? base : wrapperField.__zoom_index);
+										});
+										gantt_wrapper.find('.btn-zoom-in').off('click').on('click', () => apply_zoom(wrapperField.__zoom_index + 1));
+										gantt_wrapper.find('.btn-zoom-out').off('click').on('click', () => apply_zoom(wrapperField.__zoom_index - 1));
+										sync_zoom_toolbar();
 										const g_cont = gantt_wrapper.find(".gantt-container");
 										g_cont.css({ "overflow-x": "scroll", "overflow-y": "auto", "max-height": "100%", "position": "relative" });
 
@@ -277,17 +309,20 @@ frappe.ui.form.on("Project", {
 											});
 										});
 
-										// This frappe-gantt build marks today with `.current-highlight`
-										// (NOT `.today-highlight`, which doesn't exist here). Center on it.
-										const scroll_to_today = () => {
+										// Backup scroll: find the earliest task bar and scroll so it
+										// appears near the left edge with a small margin.
+										const scroll_to_first_task = () => {
 											const real_container = g_cont[0];
 											if (!real_container) return;
-											const today_el = real_container.querySelector(".current-highlight, .current-date-highlight, .today");
-											if (!today_el) return;
-											const container_width = real_container.clientWidth;
-											const element_left_relative = today_el.getBoundingClientRect().left - real_container.getBoundingClientRect().left;
-											const scroll_to_position = real_container.scrollLeft + element_left_relative - container_width / 2;
-											real_container.scrollTo({ left: scroll_to_position, behavior: "smooth" });
+											const bars = real_container.querySelectorAll("rect.bar");
+											if (!bars.length) return;
+											let min_x = Infinity;
+											bars.forEach((bar) => {
+												const x = parseFloat(bar.getAttribute("x"));
+												if (!isNaN(x) && x < min_x) min_x = x;
+											});
+											if (!isFinite(min_x)) return;
+											real_container.scrollTo({ left: Math.max(0, min_x - 80), behavior: "smooth" });
 										};
 										if (preserveScroll && savedScrollLeft != null) {
 											// Restore the pre-refresh scroll position. Done twice to win over
@@ -296,9 +331,9 @@ frappe.ui.form.on("Project", {
 											setTimeout(restore, 50);
 											setTimeout(restore, 200);
 										} else {
-											// scroll_to: "today" already centers via the library; this is a
-											// backup for cases where the container wasn't laid out yet.
-											setTimeout(scroll_to_today, 350);
+											// scroll_to: "start" already positions at the timeline start;
+											// this is a backup that finds the exact first task bar position.
+											setTimeout(scroll_to_first_task, 350);
 										}
 									} catch (e) { console.error("Gantt error:", e); chart_container.html('<p class="text-danger">Error initializing Gantt chart.</p>'); }
 								} else { chart_container.html('<p class="text-muted text-center p-4">Error fetching data or no tasks found.</p>'); }

--- a/project_enhancements/public/js/dashboard_components/portfolio_gantt.js
+++ b/project_enhancements/public/js/dashboard_components/portfolio_gantt.js
@@ -15,6 +15,12 @@ project_enhancements.dashboard_components.PortfolioGantt = class PortfolioGantt 
         this.ganttDataCache = null;
         this.isTogglingNode = false;
 
+        // Live Gantt instance + current zoom ladder index. Zoom persists while the
+        // dashboard tab stays open but resets to the default on a fresh page load
+        // (a new PortfolioGantt is constructed each load).
+        this.ganttInstance = null;
+        this.zoomIndex = project_enhancements.gantt_zoom.DEFAULT_INDEX.Month;
+
         // Scroll preservation across re-renders. When an action that empties the
         // chart container (e.g. toggling Detailed View) needs to keep the user's
         // scroll position, it stashes the current position here before the
@@ -73,6 +79,13 @@ project_enhancements.dashboard_components.PortfolioGantt = class PortfolioGantt 
 							<div class="dropdown-divider"></div>
 							<button class="btn btn-sm btn-primary w-100" id="apply-gantt-filters">Apply Filters</button>
 						</div>
+					</div>
+				</div>
+				<div class="d-flex align-items-center ml-auto">
+					<label class="mr-2 mb-0 font-weight-bold">Zoom:</label>
+					<div class="btn-group btn-group-sm">
+						<button class="btn btn-white border btn-gantt-zoom-out" type="button" title="Zoom out (show more)"><i class="fa fa-search-minus"></i></button>
+						<button class="btn btn-white border btn-gantt-zoom-in" type="button" title="Zoom in (show detail)"><i class="fa fa-search-plus"></i></button>
 					</div>
 				</div>
 			</div>
@@ -150,6 +163,22 @@ project_enhancements.dashboard_components.PortfolioGantt = class PortfolioGantt 
 		this.wrapper.find('.check-dropdown .dropdown-menu').on('click', function(e) {
 			e.stopPropagation();
 		});
+
+		// Zoom controls. Applying a zoom re-renders the existing Gantt in place
+		// (no data refetch) via the shared zoom ladder, preserving scroll position.
+		const Z = project_enhancements.gantt_zoom;
+		const sync_zoom = () => {
+			this.wrapper.find('.btn-gantt-zoom-out').prop('disabled', Z.is_min(this.zoomIndex));
+			this.wrapper.find('.btn-gantt-zoom-in').prop('disabled', Z.is_max(this.zoomIndex));
+		};
+		const apply_zoom = (index) => {
+			this.zoomIndex = Z.clamp(index);
+			if (this.ganttInstance) Z.apply(this.ganttInstance, this.zoomIndex);
+			sync_zoom();
+		};
+		this.wrapper.find('.btn-gantt-zoom-in').on('click', () => apply_zoom(this.zoomIndex + 1));
+		this.wrapper.find('.btn-gantt-zoom-out').on('click', () => apply_zoom(this.zoomIndex - 1));
+		sync_zoom();
 	}
 
 	async fetch_and_render_data() {
@@ -341,8 +370,10 @@ project_enhancements.dashboard_components.PortfolioGantt = class PortfolioGantt 
 		frappe.require([
 			"/assets/project_enhancements/js/lib/frappe-gantt.umd.js"
 		], () => {
-			new Gantt($chartWrapper[0], mappedItems, {
-				view_mode: "Month",
+			const zoom_level = project_enhancements.gantt_zoom.level(this.zoomIndex);
+			this.ganttInstance = new Gantt($chartWrapper[0], mappedItems, {
+				view_mode: zoom_level.view_mode,
+				column_width: zoom_level.column_width,
                 auto_move_label: true,
                 // Let the library center on today for a fresh render (it locates
                 // today via the date cells, which is reliable). On a preserve

--- a/project_enhancements/public/js/gantt_auto_scroll.js
+++ b/project_enhancements/public/js/gantt_auto_scroll.js
@@ -1,38 +1,45 @@
 /**
  * @file This script provides a robust auto-scrolling functionality for Frappe Gantt charts.
  * @description It uses a MutationObserver to detect when a Gantt chart is added to the DOM.
- * Once a chart is detected, a nested MutationObserver waits for the '.today-highlight'
- * element to be rendered, then smoothly scrolls it into the horizontal center of the view.
- * This ensures that whenever a Gantt chart is loaded, the user's attention is immediately
- * drawn to the current date, improving usability on large project timelines.
+ * Once a chart is detected, a nested MutationObserver waits for the bar elements to be
+ * rendered, then smoothly scrolls to the earliest task so the user can see where the
+ * project starts.
  */
 document.addEventListener("DOMContentLoaded", () => {
 	const GANTT_SCROLL_LOGIC = {
 		/**
-		 * Initiates the scroll to the 'today' highlight element within the Gantt chart.
+		 * Initiates the scroll to the earliest task bar within the Gantt chart.
 		 * @param {HTMLElement} gantt_container - The container of the Gantt chart SVG.
 		 */
-		scrollToToday: function (gantt_container) {
-			const today_el = gantt_container.querySelector(".today-highlight");
-			if (!today_el) return;
+		scrollToFirstTask: function (gantt_container) {
+			const bar_els = gantt_container.querySelectorAll("rect.bar");
+			if (!bar_els.length) return;
 
 			const scroll_el =
 				gantt_container.closest(".gantt-scroll-wrapper") ||
 				gantt_container.closest(".gantt-container");
 			if (!scroll_el) return;
 
-			this.executeScroll(scroll_el, today_el);
+			// Find the bar with the smallest x value (earliest task).
+			let min_x = Infinity;
+			bar_els.forEach((bar) => {
+				const x = parseFloat(bar.getAttribute("x"));
+				if (!isNaN(x) && x < min_x) min_x = x;
+			});
+
+			if (!isFinite(min_x)) return;
+
+			this.executeScroll(scroll_el, min_x);
 		},
 
 		/**
 		 * Calculates the target scroll position and performs the scroll.
 		 * @param {HTMLElement} scroll_el - The scrollable container element.
-		 * @param {HTMLElement} today_el - The element representing today's date.
+		 * @param {number} target_x - The x position of the earliest task bar.
 		 */
-		executeScroll: function (scroll_el, today_el) {
-			const container_width = scroll_el.offsetWidth;
-			const today_pos = parseFloat(today_el.getAttribute("x"));
-			const scroll_left = today_pos - container_width / 2;
+		executeScroll: function (scroll_el, target_x) {
+			// Scroll so the earliest task has a small left margin (80px).
+			const scroll_left = Math.max(0, target_x - 80);
 
 			scroll_el.scrollTo({
 				left: scroll_left,
@@ -42,24 +49,22 @@ document.addEventListener("DOMContentLoaded", () => {
 	};
 
 	/**
-	 * Watches for the '.today-highlight' element to be added to the Gantt container.
+	 * Watches for bar elements to be added to the Gantt container.
 	 * @param {HTMLElement} ganttContainer - The Gantt chart's main container element.
 	 */
 	function waitForTodayHighlight(ganttContainer) {
-		// First, check if the element already exists.
-		if (ganttContainer.querySelector(".today-highlight")) {
-			GANTT_SCROLL_LOGIC.scrollToToday(ganttContainer);
+		// First, check if bars already exist.
+		if (ganttContainer.querySelector("rect.bar")) {
+			GANTT_SCROLL_LOGIC.scrollToFirstTask(ganttContainer);
 			return;
 		}
 
-		// If not, set up an observer to wait for it.
+		// If not, set up an observer to wait for them.
 		const observer = new MutationObserver((mutations, obs) => {
 			for (const mutation of mutations) {
 				if (mutation.addedNodes.length > 0) {
-					// Check if any of the added nodes are the highlight or contain it.
-					const todayHighlight = ganttContainer.querySelector(".today-highlight");
-					if (todayHighlight) {
-						GANTT_SCROLL_LOGIC.scrollToToday(ganttContainer);
+					if (ganttContainer.querySelector("rect.bar")) {
+						GANTT_SCROLL_LOGIC.scrollToFirstTask(ganttContainer);
 						obs.disconnect(); // Clean up the observer once the job is done.
 						return;
 					}

--- a/project_enhancements/public/js/gantt_zoom.js
+++ b/project_enhancements/public/js/gantt_zoom.js
@@ -1,0 +1,73 @@
+/**
+ * @file Shared zoom ladder for every Frappe Gantt chart in this app
+ * (the Project form "Schedule" tab and the Project Dashboard portfolio Gantt).
+ *
+ * @description The +/- zoom buttons step through a single ordered ladder of
+ * (view_mode, column_width) pairs. The ladder runs from most zoomed-OUT (widest
+ * time span, least detail) to most zoomed-IN, and pixels-per-day rises
+ * monotonically across it — so even though zooming sometimes crosses a view-mode
+ * boundary (e.g. Week -> Day), it always feels like one continuous zoom.
+ *
+ * Frappe Gantt resolves a bar's column width as
+ *   options.column_width || view_mode.column_width || 45
+ * so once we set an explicit options.column_width (which we always do here), it
+ * wins over the view mode's built-in width. That is exactly what lets a single
+ * view mode host several zoom levels.
+ */
+frappe.provide("project_enhancements.gantt_zoom");
+
+(function () {
+	const ns = project_enhancements.gantt_zoom;
+
+	// Ordered from most zoomed-OUT to most zoomed-IN. The trailing comment on
+	// each line is the resulting pixels-per-day, which must stay monotonic.
+	ns.LEVELS = [
+		{ view_mode: "Month", column_width: 90 }, // ~3 px/day
+		{ view_mode: "Month", column_width: 120 }, // ~4 px/day
+		{ view_mode: "Week", column_width: 70 }, // ~10 px/day
+		{ view_mode: "Week", column_width: 140 }, // ~20 px/day
+		{ view_mode: "Day", column_width: 30 }, // 30 px/day
+		{ view_mode: "Day", column_width: 45 }, // 45 px/day
+		{ view_mode: "Day", column_width: 70 }, // 70 px/day
+		{ view_mode: "Half Day", column_width: 45 }, // ~90 px/day
+		{ view_mode: "Quarter Day", column_width: 45 }, // ~180 px/day
+	];
+
+	// Per-chart default ladder index, picked so first load looks exactly like it
+	// did before zoom existed (Project form = Day/45, dashboard = Month/120).
+	ns.DEFAULT_INDEX = { Day: 5, Month: 1 };
+
+	// First ladder index for each view mode. Used to keep the +/- zoom level
+	// coherent when a user clicks a discrete view-mode button (Project form).
+	ns.BASE_INDEX = { Month: 1, Week: 3, Day: 5, "Half Day": 7, "Quarter Day": 8 };
+
+	ns.clamp = function (i) {
+		return Math.max(0, Math.min(ns.LEVELS.length - 1, i));
+	};
+
+	ns.level = function (i) {
+		return ns.LEVELS[ns.clamp(i)];
+	};
+
+	/**
+	 * Apply a zoom index to a live Gantt instance. update_options() re-renders
+	 * while maintaining the current horizontal scroll position, so zooming never
+	 * snaps the viewport back to today.
+	 * @param {Gantt} gantt - A Frappe Gantt instance.
+	 * @param {number} i - Target ladder index (clamped to range).
+	 * @returns {number} The clamped index that was applied.
+	 */
+	ns.apply = function (gantt, i) {
+		const lvl = ns.level(i);
+		gantt.update_options({ view_mode: lvl.view_mode, column_width: lvl.column_width });
+		return ns.clamp(i);
+	};
+
+	ns.is_min = function (i) {
+		return ns.clamp(i) <= 0;
+	};
+
+	ns.is_max = function (i) {
+		return ns.clamp(i) >= ns.LEVELS.length - 1;
+	};
+})();


### PR DESCRIPTION
## Summary

- **Scroll to earliest task** — Project form Schedule tab now lands on the leftmost task bar on first load instead of today. Uses `scroll_to: "start"` + a DOM backup (finds `rect.bar` with the smallest `x`); in-place refreshes still restore the previous viewport.
- **Viewport-fit Gantt height** — Replaces the hardcoded `550px` with `window.innerHeight - wrapper.top - 24px` so the chart fills the visible area and both scrollbars are always accessible without page-level scrolling.
- **+/− zoom controls on both Gantt charts** — A new shared `gantt_zoom.js` module provides a 9-step `(view_mode, column_width)` ladder (Quarter-Day → Month). Zoom applies in-place via `update_options()`, preserving scroll position.
  - **Project form Schedule tab**: − / + buttons added beside the existing view-mode buttons. Clicking a view-mode button also syncs the ladder, keeping +/− coherent. Default unchanged (Day / 45 px).
  - **Portfolio Gantt (Dashboard)**: − / + buttons added to the controls bar. Zoom persists across filter and detail-view re-renders within the session. Default unchanged (Month / 120 px).

## Files changed

| File | Change |
|---|---|
| `project_enhancements/public/js/gantt_zoom.js` | **New** — shared 9-step zoom ladder module |
| `project_enhancements/hooks.py` | Register `gantt_zoom.js` in `app_include_js` |
| `project_enhancements/project_enhancements/doctype/project/project.js` | Viewport height, scroll-to-first-task, zoom buttons wired |
| `project_enhancements/public/js/dashboard_components/portfolio_gantt.js` | Zoom buttons, `ganttInstance` stored, zoom level applied on render |
| `project_enhancements/public/js/gantt_auto_scroll.js` | Updated dormant global observer to scroll to earliest bar |

## Reviewer notes

- `gantt_zoom.js` is a new bundled asset — requires `bench build` + `bench clear-cache` before the buttons appear in a dev/staging environment.
- Zoom is **session-only** (no localStorage persistence); the chart always opens at the default zoom level on each page load.
- The +/− buttons disable at the ladder ends (no wrap-around).
- The third Gantt (Tasks View drill-down in `tasks_view.js`) is untouched — raise a follow-up if zoom is needed there too.

## Test plan

- [ ] Open a Project form → Schedule tab; confirm Gantt scrolls to the first task, not today
- [ ] Confirm the chart fills the viewport (no need to scroll the page to see the horizontal scrollbar)
- [ ] Click **−** and **+**: confirm view mode and column width change; confirm buttons disable at limits
- [ ] Click a view-mode button (e.g. Month); confirm +/− still step coherently from that mode
- [ ] Drag a task bar to change dates; confirm scroll position is preserved after the refresh
- [ ] Open Projects Dashboard → Portfolio Gantt; confirm − / + buttons appear and zoom works
- [ ] Toggle Detailed View or change a status filter; confirm zoom level survives the re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)