### PR TITLE
Fix exploded Columns dropdown in Project Dashboard

### DIFF
--- a/Custom HTML Block/projects_dashboard.css
+++ b/Custom HTML Block/projects_dashboard.css
@@ -59,6 +59,36 @@
 
 .check-dropdown .dropdown-menu.show { display: block !important; }
 
+/* Column Selector Dropdown */
+.dashboard-list-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 0.5rem; }
+.dashboard-column-selector { position: relative; display: inline-block; }
+.column-selector-menu {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    z-index: 1050;
+    background: #fff;
+    border: 1px solid #dee2e6;
+    border-radius: 6px;
+    padding: 6px 0;
+    min-width: 160px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+.column-selector-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    margin: 0;
+    font-weight: normal;
+    cursor: pointer;
+    white-space: nowrap;
+}
+.column-selector-item:hover { background-color: #f8f9fa; }
+.column-selector-item input { margin: 0; }
+.hidden-column { display: none !important; }
+
 
 /* ========================================================================= */
 /* BASE SVG RULES TO PREVENT BLACK BOX RENDERING & FIX STICKY HEADERS        */


### PR DESCRIPTION
## What changed

Added the column-selector CSS rules directly to `Custom HTML Block/projects_dashboard.css`:
- `.dashboard-list-toolbar`
- `.dashboard-column-selector`
- `.column-selector-menu` (with `display: none` so it's a real dropdown)
- `.column-selector-item` / hover state
- `.hidden-column`

## Why

The `ColumnSelector` component renders a "Columns" button with a dropdown of checkboxes. The required styles only lived in `task_tree.css`, which isn't loaded in the Custom HTML Block context. Without those rules, `.column-selector-menu` had no `display: none`, so the menu rendered inline as an always-visible "exploded" list of checkboxes instead of a dropdown. The missing `.hidden-column` rule also meant toggling a column off had no visual effect.

## Reviewer notes

- This duplicates the rules already present in `task_tree.css` because the Custom HTML Block doesn't share that stylesheet. If these contexts are unified later, the duplication can be removed.
- No JS changes — the `ColumnSelector` class behavior was already correct; this is purely the missing styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)