### PR TITLE
Use custom fields for Project Brief PM/Tech Lead/Value, brand as Sapphire Fountains

### DIFF
--- a/project_enhancements/project_enhancements/doctype/project/project.py
+++ b/project_enhancements/project_enhancements/doctype/project/project.py
@@ -12,9 +12,9 @@ def get_project_brief_data(project_name):
 	"Project Brief" form). This is a *display-only* feature: every value is
 	pulled from fields that already exist on the Project (and, where helpful,
 	the linked Customer's default Address/Contact). Fields the template asks
-	for but which have no source in the system (PM, Tech Lead, contract type,
-	fee/contingency, etc.) are returned blank so the brief renders as a
-	fillable form, just like the printed original.
+	for but which have no source in the system (kick-off date, lien notice
+	date, contract type, fee/contingency, etc.) are returned blank so the
+	brief renders as a fillable form, just like the printed original.
 
 	Args:
 	    project_name (str): The Project document name (e.g. "PROJ-0567").
@@ -24,9 +24,7 @@ def get_project_brief_data(project_name):
 	"""
 	doc = frappe.get_doc("Project", project_name)
 
-	# `total_sales_amount` / `estimated_costing` are the closest standard
-	# stand-ins for the template's "Contract Value" / "Contract Amount".
-	contract_value = doc.get("total_sales_amount") or doc.get("estimated_costing") or 0
+	contract_value = doc.get("custom_project_dollar_amount") or 0
 
 	# Project notes is a Text Editor (HTML); strip tags for a clean brief.
 	description = doc.get("custom_project_description") or strip_html(doc.get("notes") or "")
@@ -40,9 +38,9 @@ def get_project_brief_data(project_name):
 		"start_date": doc.get("expected_start_date"),
 		"completion_date": doc.get("expected_end_date"),
 		"description": (description or "").strip(),
+		"pm": doc.get("custom_project_owner") or "",
+		"tech_lead": doc.get("custom_technical_lead") or "",
 		# No native Project source — left blank to be filled in on the printout.
-		"pm": "",
-		"tech_lead": "",
 		"kickoff_meeting_date": "",
 		"prelim_lien_notice_date": "",
 		"owner": doc.get("customer") or "",

--- a/project_enhancements/public/js/project_brief.js
+++ b/project_enhancements/public/js/project_brief.js
@@ -98,7 +98,7 @@ function build_brief_html(d) {
 
 	<!-- Header -->
 	<div class="sf-header">
-		<div class="sf-logo">Sapphire<span class="sf-dot">.</span></div>
+		<div class="sf-logo">Sapphire Fountains<span class="sf-dot">.</span></div>
 		<div class="sf-prj">
 			<div class="sf-label">Project Number</div>
 			<div class="sf-prj-num">${slot(d.project_number)}</div>
@@ -181,7 +181,7 @@ function build_brief_html(d) {
 		<div class="sf-section-title">Payment Process</div>
 		<div class="sf-payment">
 			Payment requests are due to the owner on the <strong>Last Day of each Month</strong>.
-			Subcontractor and Supplier invoices are due to Sapphire by the <strong>25th of each month</strong>
+			Subcontractor and Supplier invoices are due to Sapphire Fountains by the <strong>25th of each month</strong>
 			(projecting expenses to the end of the month).
 		</div>
 		<div class="sf-grid sf-grid-2 sf-mt">


### PR DESCRIPTION
## Summary
- Source the Project Brief's PM, Tech Lead, and Project/Contract Value fields from `custom_project_owner`, `custom_technical_lead`, and `custom_project_dollar_amount` instead of leaving them blank or using best-effort stand-ins (`total_sales_amount`/`estimated_costing`)
- Use the full "Sapphire Fountains" brand name in the brief header logo and the payment-process note (previously just "Sapphire")

## Test plan
- [ ] Open a Project with `custom_project_owner`, `custom_technical_lead`, and `custom_project_dollar_amount` populated, click "Project Brief", and confirm PM, Tech Lead, and Project/Contract Value render correctly
- [ ] Confirm the brief header and payment-process text show "Sapphire Fountains"

🤖 Generated with [Claude Code](https://claude.com/claude-code)